### PR TITLE
Add garden search

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,6 +1,7 @@
 class GardensController < ApplicationController
   before_action :require_user, except: [:show]
 
+  def index; end
 
   def show
     # move conn, response, parse to service and facade once we better udnerstand api response structure

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,9 @@
             <a class="nav-link" href="/dashboard">Profile</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="/gardens">Garden Search</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="/logout">Logout</a>
           </li>
         </ul>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -100,7 +100,7 @@ body {font-family: "Lato", sans-serif}
   <div class="w3-container w3-content w3-center">
     <div class="w3-row w3-padding-32" >
 
-<!-- Login with Google button -->
+      <!-- Login with Google button -->
       <div class="w3-panel">
         <script src="https://apis.google.com/js/platform.js" async defer></script>
         <%= link_to "Login with Google", "/auth/google_oauth2", class: "w3-btn w3-blue-grey w3-block" %>
@@ -109,6 +109,10 @@ body {font-family: "Lato", sans-serif}
 <!-- Visit the Learn More page button -->
       <div class="w3-panel">
         <%= link_to "Be The Change. Learn More", "/learn_more", class: "w3-btn w3-light-green w3-block" %>
+      </div>
+
+      <div class="w3-panel">
+        <%= link_to "Garden Search", "/gardens", class: "w3-btn w3-blue-grey  w3-block" %>
       </div>
 
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/privacy', to: 'privacy#index'
   resources :users, except: [:index]
   get "/dashboard", to: "dashboard#show"
-  resources :gardens, except: [:index]
+  resources :gardens
   resources :plants, except: [:index]
   resources :sensors, except: [:index]
   get "/learn_more", to: "learn_more#show"

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Edit Garden Page' do
 
     it 'sees four input fields, two radio buttons and a button to submit' do
       visit "/gardens/#{@garden[:id]}/edit"
+      
       expect(page).to have_selector("input[value='#{@garden[:attributes][:name]}']")
       expect(page).to have_selector("input[value='#{@garden[:attributes][:latitude]}']")
       expect(page).to have_selector("input[value='#{@garden[:attributes][:longitude]}']")

--- a/spec/features/gardens/index_spec.rb
+++ b/spec/features/gardens/index_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'New Garden Page' do
+  describe 'a logged in user' do
+    before :each do
+      @user = User.new({id: 1,
+                      attributes: {
+                          email: '123@gmail.com' },
+                      relationships: {
+                          gardens: {
+                              data: [ { id: 1,
+                                        attributes: {
+                                            name: 'My Garden',
+                                            latitude: 23.0,
+                                            longitude: 24.0,
+                                            description: 'Simple Garden',
+                                            private: false }} ] }}})
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+  end
+end 

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -187,12 +187,13 @@ RSpec.describe 'Navbar' do
 
   it "can see my gardens, my impact, learn more, profile and logout on learn more page" do
     visit "/learn_more"
-
+    save_and_open_page
     within "#navbar-#{@user.id}" do
       expect(page).to have_link('My Gardens')
       expect(page).to have_link('My Impact')
       expect(page).to have_link('Learn More')
       expect(page).to have_link('Profile')
+      expect(page).to have_link('Garden Search')
       expect(page).to have_link('Logout')
     end
   end

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe 'Navbar' do
 
   it "can see my gardens, my impact, learn more, profile and logout on learn more page" do
     visit "/learn_more"
-    save_and_open_page
+  
     within "#navbar-#{@user.id}" do
       expect(page).to have_link('My Gardens')
       expect(page).to have_link('My Impact')

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe 'Welcome' do
       visit root_path
 
       click_link "Be The Change. Learn More"
+
       expect(current_path).to eq(learn_more_path)
     end
 
@@ -76,6 +77,14 @@ RSpec.describe 'Welcome' do
       visit root_path
 
       expect(page).to have_link("Login with Google")
+    end
+
+    it "has a link to pbulic gardens (gardens index page)" do
+      visit root_path
+      expect(page).to have_link("Garden Search")
+      click_link "Garden Search"
+      save_and_open_page
+      expect(current_path).to eq('/gardens')
     end
     # We are not sure how to test this quite yet. I think once the OAuth is complete this can be tested.
     xit "expects to be sent to the Google auth when the button is clicked" do

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -79,11 +79,10 @@ RSpec.describe 'Welcome' do
       expect(page).to have_link("Login with Google")
     end
 
-    it "has a link to pbulic gardens (gardens index page)" do
+    it "has a link to public gardens (gardens index page)" do
       visit root_path
       expect(page).to have_link("Garden Search")
       click_link "Garden Search"
-      save_and_open_page
       expect(current_path).to eq('/gardens')
     end
     # We are not sure how to test this quite yet. I think once the OAuth is complete this can be tested.


### PR DESCRIPTION
Created a 'Garden Search' button in the navbar and on the welcome page.

The route and action in the controller has been added.

This is a good foundation for who ever wants to continue on with the gardens index  