### PR TITLE
Welcome Page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'mini_racer', platforms: :ruby
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-# gem 'bootstrap'
+gem 'bootstrap'
 gem 'faraday'
 gem 'json'
 gem 'omniauth-google-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,15 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    autoprefixer-rails (10.0.1.0)
+      execjs
     bindex (0.8.1)
     bootsnap (1.4.9)
       msgpack (~> 1.0)
+    bootstrap (4.5.2)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 1.14.3, < 2)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.33.0)
@@ -174,6 +180,7 @@ GEM
       rspec (>= 2.14)
     os (1.1.1)
     pg (1.2.3)
+    popper_js (1.16.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -254,6 +261,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
     signet (0.14.0)
@@ -310,6 +325,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap
   byebug
   capybara
   factory_bot_rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,5 +13,5 @@
  */
 
 // Custom bootstrap variables must be set or imported *before* bootstrap.
-// @import "bootstrap";
-// .solar-nav {float: right}
+@import "bootstrap";
+.solar-nav {float: right}

--- a/app/controllers/learn_more_controller.rb
+++ b/app/controllers/learn_more_controller.rb
@@ -1,4 +1,4 @@
 class LearnMoreController < ApplicationController
-  before_action :require_user
+  # before_action :require_user
   def show; end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,3 @@
 class WelcomeController < ApplicationController
-  def index
-    if !current_user.nil?
-      redirect_to dashboard_path
-    end
-  end
+  def index; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,37 +1,45 @@
 <!DOCTYPE html>
 <html>
  <head>
-    <title>FrontEndRails</title>
+    <title>My Solar Garden</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag    'application', media: 'all' %>
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <style>
+      body {font-family: "Lato", sans-serif}
+      .mySlides {display: none}
+    </style>
     <%= javascript_include_tag 'application' %>
 </head>
 <body>
   <% if !current_user.nil? %>
     <nav class="navbar navbar-expand-xl bg-dark navbar-dark sticky-top" id="navbar-<%= current_user.id %>">
-      <a class="navbar-brand" href="/">Home</a>
+      <a class="navbar-brand" href="<%=root_path%>">Welcome</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse navbar-expand-xl" id="collapsibleNavbar">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="/gardens">My Gardens</a>
+            <a class="nav-link" href="<%=gardens_path%>">My Gardens</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/impact">My Impact</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/learn_more">Learn More</a>
+            <a class="nav-link" href="<%=learn_more_path%>">Learn More</a>
           </li>
         </ul>
         <ul class="nav justify-content-end">
           <li class="nav-item">
-            <a class="nav-link" href="/dashboard">Profile</a>
+            <a class="nav-link" href="<%=dashboard_path%>">Profile</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/logout">Logout</a>
+            <a class="nav-link" href="<%=logout_path%>">Logout</a>
           </li>
         </ul>
       </div>

--- a/app/views/learn_more/show.html.erb
+++ b/app/views/learn_more/show.html.erb
@@ -32,8 +32,21 @@
     </div>
     <% if current_user.nil? %>
       <div class="w3-panel">
+        <%= link_to "Back to Welcome", "/", class: "w3-btn w3-light-green w3-block" %>
+      </div>
+      <div class="w3-panel">
         <script src="https://apis.google.com/js/platform.js" async defer></script>
         <%= link_to "Login with Google", "/auth/google_oauth2", class: "w3-btn w3-blue-grey w3-block" %>
+      </div>
+      <div class="w3-panel w3-pale-blue w3-block w3-center">
+        <h4 >Login with Google to:</h4>
+        <p class="w3-justify w3-center ">
+          - Set up a garden - <br>
+          - Track your sensor data - <br>
+          - Connect with your community - <br>
+          - Track your garden's carbon impact - <br>
+          - Track the health of your plants and soil -
+        </p>
       </div>
     <% end %>
   </div>

--- a/app/views/learn_more/show.html.erb
+++ b/app/views/learn_more/show.html.erb
@@ -1,0 +1,40 @@
+<div class="w3-content" style="max-width:2000px;margin-top:46px">
+
+  <!-- The Learn More Section -->
+  <div class="w3-container w3-content w3-center w3-padding-21" style="max-width:916px" id="learn more">
+    <h2 class="w3-wide">Learn More</h2>
+  </div>
+
+  <div class="w3-container w3-content w3-padding-21" style="max-width:916px" id="learn more">
+    <p class="w3-justify"><h3>Question 1:</h3>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+      ex ea commodo consequat.<br><br>
+    <h3>Question 2:</h3>
+      Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.<br><br>
+    <h3>Question 3:</h3>
+      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum consectetur
+      adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br><br>
+    <h3>Question 4:</h3>
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <div class="w3-row w3-padding-32">
+      <div class="w3-third">
+        <p>Name</p>
+        <img src="https://media.wired.com/photos/593258d526780e6c04d2b157/191:100/w_1280,c_limit/garden-sensor-ft.jpg" class="w3-round w3-margin-bottom" alt="Random Name" style="width:250px">
+      </div>
+      <div class="w3-third">
+        <p>Name</p>
+        <img src="https://www.trees.com/sites/default/files/2019-09/soil-moisture-meter.jpg" class="w3-round w3-margin-bottom" alt="Random Name" style="width:250px">
+      </div>
+      <div class="w3-third">
+        <p>Name</p>
+        <img src="https://www.cooking-hacks.com/media/cooking/images/documentation/open_garden/indoor_plant_4_small.png" class="w3-round" alt="Random Name" style="width:250px">
+      </div>
+    </div>
+    <% if current_user.nil? %>
+      <div class="w3-panel">
+        <script src="https://apis.google.com/js/platform.js" async defer></script>
+        <%= link_to "Login with Google", "/auth/google_oauth2", class: "w3-btn w3-blue-grey w3-block" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,18 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<title>W3.CSS Template</title>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-<style>
-body {font-family: "Lato", sans-serif}
-.mySlides {display: none}
-</style>
-<body>
-
-<!-- Page content -->
 <div class="w3-content" style="max-width:2000px;margin-top:46px">
 
   <!-- The App description Section -->
@@ -120,7 +105,7 @@ body {font-family: "Lato", sans-serif}
 </div>
 <script>
 
-// Automatic Slideshow - change image every 4 seconds
+// Automatic Slideshow - change image every 6 seconds
 var myIndex = 0;
 carousel();
 
@@ -136,5 +121,3 @@ function carousel() {
   setTimeout(carousel, 6000);
 }
 </script>
-</body>
-</html>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -30,9 +30,6 @@ body {font-family: "Lato", sans-serif}
     <img src="https://i.imgur.com/ESOXGPn.jpg" style="width:916px">
   </div>
   <div class="mySlides w3-display-container w3-center">
-    <img src="https://i.imgur.com/kH35Q3r.jpg" style="width:916px">
-  </div>
-  <div class="mySlides w3-display-container w3-center">
     <img src="https://i.imgur.com/JZzjPUH.jpg" style="width:916px">
   </div>
   <div class="mySlides w3-display-container w3-center">
@@ -100,17 +97,24 @@ body {font-family: "Lato", sans-serif}
   <div class="w3-container w3-content w3-center">
     <div class="w3-row w3-padding-32" >
 
+<!-- Visit the Learn More page button -->
+      <div class="w3-panel">
+        <%= link_to "Be The Change. Learn More", "/learn_more", class: "w3-btn w3-light-green w3-block" %>
+      </div>
+
 <!-- Login with Google button -->
       <div class="w3-panel">
         <script src="https://apis.google.com/js/platform.js" async defer></script>
         <%= link_to "Login with Google", "/auth/google_oauth2", class: "w3-btn w3-blue-grey w3-block" %>
       </div>
 
-<!-- Visit the Learn More page button -->
-      <div class="w3-panel">
-        <%= link_to "Be The Change. Learn More", "/learn_more", class: "w3-btn w3-light-green w3-block" %>
+      <div class="w3-panel w3-pale-blue w3-block">
+        <h4 >Why we use Google for Login:</h4>
+        <p class="w3-justify w3-center "> - Google already has strong authorization, helping us protect your data - <br>
+          - Google integration helps you share your environmental impact more easily - <br>
+          - <%= link_to "Google has committed", "https://sustainability.google/commitments/"%> to be the first major company to operate carbon free by 2030. -
+        </p>
       </div>
-
     </div>
   </div>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,13 +1,20 @@
 <div class="w3-content" style="max-width:2000px;margin-top:46px">
 
   <!-- The App description Section -->
-  <div class="w3-container w3-content w3-center w3-padding-64" style="max-width:950px" id="app_info">
+  <div class="w3-container w3-content w3-center " style="max-width:950px" id="app_info">
     <h2 class="w3-wide">My Solar Garden Project</h2>
     <p class="w3-opacity"><i>We love the planet</i></p>
-    <p class="w3-justify">Here is where all of the amazing things we would like to say about our app will go.
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
-      ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum consectetur
-      adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <p class="w3-justify">
+      My Solar Garden is an impact driven app here to support you in helping to keep our planet thriving.  By signing up with My Solar Garden, you will be able to track your personal garden's health, as well as your personal carbon impact.<br><br>
+
+      My Solar Garden can give you daily updates as to how much moisture and light it's receiving.  It will also provide cultivating innovative regenerative ideas for how to get your garden healthy and thriving to continue to make a positivie impact on our environment.<br><br>
+
+      My Solar Garden also allows you to see the growing community of Solar Gardeners, as well as their carbon impact.<br><br>
+
+      We want to live in balance with the diversity of our environemnet.  It all starts with healthy soil, and that's what we will help you learn how to cultivate. It starts with one person.<br><br>
+
+      That person, is you.
+    </p>
   </div>
 
   <!-- Automatic Slideshow Images -->
@@ -94,10 +101,13 @@
       </div>
 
       <div class="w3-panel w3-pale-blue w3-block">
-        <h4 >Why we use Google for Login:</h4>
-        <p class="w3-justify w3-center "> - Google already has strong authorization, helping us protect your data - <br>
-          - Google integration helps you share your environmental impact more easily - <br>
-          - <%= link_to "Google has committed", "https://sustainability.google/commitments/"%> to be the first major company to operate carbon free by 2030. -
+        <h4 >Login with Google to:</h4>
+        <p class="w3-justify w3-center ">
+          - Set up a garden - <br>
+          - Track your sensor data - <br>
+          - Connect with your community - <br>
+          - Track your garden's carbon impact - <br>
+          - Track the health of your plants and soil -
         </p>
       </div>
     </div>

--- a/spec/features/learn_more/show_spec.rb
+++ b/spec/features/learn_more/show_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe 'Learn More page' do
       expect(page).to have_css("img[src*='https://www.trees.com/sites/default/files/2019-09/soil-moisture-meter.jpg']")
       expect(page).to have_css("img[src*='https://www.cooking-hacks.com/media/cooking/images/documentation/open_garden/indoor_plant_4_small.png']")
     end
+
+    it "expects to be sent to the Learn More page when Learn more button is clicked" do
+      visit learn_more_path
+
+      click_link "Back to Welcome"
+      expect(current_path).to eq(root_path)
+    end
+
+    it "expects to see a Login with Google button" do
+      visit root_path
+
+      expect(page).to have_link("Login with Google")
+    end
+
+    it "expects to see a description as to why to log in with google block section" do
+      visit root_path
+
+      expect(page).to have_content("Login with Google to:")
+      expect(page).to have_content("- Set up a garden -")
+      expect(page).to have_content("- Track your sensor data -")
+      expect(page).to have_content("- Connect with your community -")
+      expect(page).to have_content("- Track your garden's carbon impact -")
+      expect(page).to have_content("- Track the health of your plants and soil -")
+    end
   end
 
   describe 'a logged in user' do

--- a/spec/features/learn_more/show_spec.rb
+++ b/spec/features/learn_more/show_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'Learn More page' do
+
+  describe 'as a visitor' do
+    before :each do
+      visit learn_more_path
+    end
+
+    it "visitor does not see a navbar" do
+      expect(page).to_not have_link("My Gardens")
+      expect(page).to_not have_link("My Impact")
+      expect(page).to_not have_link("Learn More")
+      expect(page).to_not have_link("Logout")
+      expect(page).to_not have_link("Profile")
+    end
+
+    it "a visitor can see" do
+      #this will be a header for the page itself
+      expect(page).to have_content("Learn More")
+      expect(page).to have_link("Login with Google")
+      expect(page).to have_css("img[src*='https://media.wired.com/photos/593258d526780e6c04d2b157/191:100/w_1280,c_limit/garden-sensor-ft.jpg']")
+      expect(page).to have_css("img[src*='https://www.trees.com/sites/default/files/2019-09/soil-moisture-meter.jpg']")
+      expect(page).to have_css("img[src*='https://www.cooking-hacks.com/media/cooking/images/documentation/open_garden/indoor_plant_4_small.png']")
+    end
+  end
+
+  describe 'a logged in user' do
+    before :each do
+      @user = User.new({id: 1,
+                      attributes: {
+                          email: '123@gmail.com' },
+                      relationships: {
+                          gardens: {
+                              data: [] }}})
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit learn_more_path
+    end
+
+    it "a logged in user does not see" do
+      expect(page).to_not have_link("Login with Google")
+    end
+
+    it "a logged in user can see a navbar" do
+      expect(page).to have_link("My Gardens")
+      expect(page).to have_link("My Impact")
+      expect(page).to have_link("Learn More")
+      expect(page).to have_link("Logout")
+      expect(page).to have_link("Profile")
+    end
+
+    it "a logged in user can see" do
+      expect(page).to have_content("Learn More")
+      expect(page).to have_css("img[src*='https://media.wired.com/photos/593258d526780e6c04d2b157/191:100/w_1280,c_limit/garden-sensor-ft.jpg']")
+      expect(page).to have_css("img[src*='https://www.trees.com/sites/default/files/2019-09/soil-moisture-meter.jpg']")
+      expect(page).to have_css("img[src*='https://www.cooking-hacks.com/media/cooking/images/documentation/open_garden/indoor_plant_4_small.png']")
+    end
+  end
+end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe 'Welcome' do
       @garden = @user.gardens.first
     end
 
-    it "will send a logged in user to their dashboard instead of showing the welcome page" do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
-      visit root_path
-
-      expect(current_path).to eq(dashboard_path)
-    end
-
     it "expects to see a My Solar Garden Project banner" do
       visit root_path
 

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -40,13 +40,18 @@ RSpec.describe 'Welcome' do
     it "expects to see a description block section" do
       visit root_path
 
-      expect(page).to have_content("Lorem ipsum dolor sit amet")
+      expect(page).to have_content("My Solar Garden is an impact")
     end
 
-    it "expects to see a description of why we're using Google OAuth" do
+    it "expects to see a description as to why to log in with google block section" do
       visit root_path
 
-      expect(page).to have_content("Why we use Google for Login:")
+      expect(page).to have_content("Login with Google to:")
+      expect(page).to have_content("- Set up a garden -")
+      expect(page).to have_content("- Track your sensor data -")
+      expect(page).to have_content("- Connect with your community -")
+      expect(page).to have_content("- Track your garden's carbon impact -")
+      expect(page).to have_content("- Track the health of your plants and soil -")
     end
 
     it "expects to see an image section with automation" do

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -48,9 +48,13 @@ RSpec.describe 'Welcome' do
     it "expects to see a description block section" do
       visit root_path
 
-      within ".w3-justify" do
-        expect(page).to have_content("Lorem ipsum dolor sit amet")
-      end
+      expect(page).to have_content("Lorem ipsum dolor sit amet")
+    end
+
+    it "expects to see a description of why we're using Google OAuth" do
+      visit root_path
+
+      expect(page).to have_content("Why we use Google for Login:")
     end
 
     it "expects to see an image section with automation" do


### PR DESCRIPTION
# Welcome Page/Learn More Page

Go get the basic skeletal structure of the webpages. API calls are not made in this PR.

## View Pages

### ```GET / ``` - welcome

Displays the Welcome/landing page for our app. On this page we added: 
- a section describing why we are using Google

### ```GET / learn_more``` - learn_more

Displays a basic set up for the Learn More page, which should be filled out at a later date with information we as a group feel would be best to be there.

## Additional Notes

I've also updated the gems and application.scss so that navigation styling works correctly (hopefully).

Currently all tests are passing with 96.55% covered. The lines that aren't being hit are lines that will be hit when sensors, profile, and plants pages are made, and when OAuth has been implemented, to take care of the lines not being tested in the nav_spec and welcome_index_spec.