### PR TITLE
Fixing skipped tests

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,14 +10,14 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    #session[:user_id] = nil
+    session[:user_id] = nil
     flash[:success] = "You've made an impact today.  We hope to see you again tomorrow."
     redirect_to root_path
-  end 
-  
+  end
+
   private
 
   def auth_hash
     request.env["omniauth.auth"]
-  end 
+  end
 end

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -1,219 +1,233 @@
 require 'rails_helper'
 
 RSpec.describe 'Navbar' do
-  before :each do
-    @plant = Plant.new({
-                        id:1,
+  describe "when using 'allow_any_instance_of' method of logging a user in" do
+    before :each do
+      @plant = Plant.new({
+                          id:1,
+                          attributes: {
+                            image: "url",
+                            name: 'name',
+                            species: 'species',
+                            description: 'description',
+                            light_requirements: 'alot',
+                            water_requirements: 'medium',
+                            when_to_plant: 'spring',
+                            harvest_time: 'now',
+                            common_pests: 'beetles'
+                          }})
+
+      @garden = { id: 4,
+                attributes: {
+                    name: 'My Garden',
+                    latitude: 23.0,
+                    longitude: 24.0,
+                    description: 'Simple Garden',
+                    private: false },
+                relationships: { plants: {
+                                    data: []},
+                                  users: {
+                                    data: [{id: "4", type: "user"}]},
+                                 sensors: {
+                                    data: []}}}
+
+      @sensor = Sensor.new({id: 1,
                         attributes: {
-                          image: "url",
-                          name: 'name',
-                          species: 'species',
-                          description: 'description',
-                          light_requirements: 'alot',
-                          water_requirements: 'medium',
-                          when_to_plant: 'spring',
-                          harvest_time: 'now',
-                          common_pests: 'beetles'
-                        }})
+                          sensor_type: 1298,
+                          min_threshold: 30,
+                          max_threshold: 390
+                        },
+                        relationships:
+                        {
+                          garden:{data:{id:@garden[:id]}}
+                        }
+                         })
 
-    @garden = { id: 4,
-              attributes: {
-                  name: 'My Garden',
-                  latitude: 23.0,
-                  longitude: 24.0,
-                  description: 'Simple Garden',
-                  private: false },
-              relationships: { plants: {
-                                  data: []},
-                                users: {
-                                  data: [{id: "4", type: "user"}]},
-                               sensors: {
-                                  data: []}}}
-
-    @sensor = Sensor.new({id: 1,
+      @user = User.new({id: 4,
                       attributes: {
-                        sensor_type: 1298,
-                        min_threshold: 30,
-                        max_threshold: 390
-                      },
-                      relationships:
-                      {
-                        garden:{data:{id:@garden[:id]}}
-                      }
-                       })
+                          email: '123@gmail.com' },
+                      relationships: {
+                          gardens: {
+                              data: [ @garden ] }}})
 
-    @user = User.new({id: 4,
-                    attributes: {
-                        email: '123@gmail.com' },
-                    relationships: {
-                        gardens: {
-                            data: [ @garden ] }}})
+      @garden = @user.gardens.first
 
-    @garden = @user.gardens.first
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      response = File.read('spec/fixtures/public_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/#{@garden[:id]}").to_return(status: 200, body: response)
+    end
 
-    response = File.read('spec/fixtures/public_garden.json')
-    stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/#{@garden[:id]}").to_return(status: 200, body: response)
-  end
+    it "can see my gardens, my impact, learn more, profile and logout on profile page" do
+      visit "/users/#{@user.id}"
 
-  it "can see my gardens, my impact, learn more, profile and logout on profile page" do
-    visit "/users/#{@user.id}"
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
 
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
+    it "can see my gardens, my impact, learn more, profile and logout on dashboard" do
+      visit "/dashboard"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on garden show page" do
+      visit "/gardens/#{@garden[:id]}"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on garden update page" do
+      visit "/gardens/#{@garden[:id]}/edit"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on create garden page" do
+      visit "/gardens/new"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on plant show page" do
+      visit "/plants/#{@plant.id}"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on plant new page" do
+      visit "/plants/new"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on plant update page" do
+      visit "/plants/update"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on sensor show page" do
+      visit "/sensors/#{@sensor.id}"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on sensor new page" do
+      visit "/sensors/new"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on sensor update page" do
+      visit "/sensors/update"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
+    end
+
+    it "can see my gardens, my impact, learn more, profile and logout on learn more page" do
+      visit "/learn_more"
+
+      within "#navbar-#{@user.id}" do
+        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('My Impact')
+        expect(page).to have_link('Learn More')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Logout')
+      end
     end
   end
 
-  it "can see my gardens, my impact, learn more, profile and logout on dashboard" do
-    visit "/dashboard"
+  # Turns out if you do the ApplicationController shortcut to make :current_user equal @user, then even if you do the destroy action, there isn't really a way to log the user out, so :current_user is still not nil, so the welcome page won't ever not show the nav bar in this test.  The way around this is to have in the 'before do' the user log in through OAuth or what have you, and then in the test below, have them log out.  That's not working out however.
+  describe "logging in with Login button" do
+    before :each do
+      @user = User.new({id: 4,
+                      attributes: {
+                          email: '123@gmail.com' },
+                      relationships: {
+                          gardens: {
+                              data: [ ] }}})
+      visit root_path
 
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
+      click_link "Login with Google"
     end
-  end
 
-  it "can see my gardens, my impact, learn more, profile and logout on garden show page" do
-    visit "/gardens/#{@garden[:id]}"
+    it "no longer sees my gardens, my impact, learn more, profile and logout on welcome page when not logged in" do
 
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
+      click_on 'Logout'
+
+      expect(current_path).to eq(root_path)
+
+      expect(page).to_not have_link('My Gardens')
+      expect(page).to_not have_link('My Impact')
+      expect(page).to_not have_link('Learn More')
+      expect(page).to_not have_link('Profile')
+      expect(page).to_not have_link('Logout')
     end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on garden update page" do
-    visit "/gardens/#{@garden[:id]}/edit"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on create garden page" do
-    visit "/gardens/new"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on plant show page" do
-    visit "/plants/#{@plant.id}"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on plant new page" do
-    visit "/plants/new"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on plant update page" do
-    visit "/plants/update"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on sensor show page" do
-    visit "/sensors/#{@sensor.id}"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on sensor new page" do
-    visit "/sensors/new"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on sensor update page" do
-    visit "/sensors/update"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  it "can see my gardens, my impact, learn more, profile and logout on learn more page" do
-    visit "/learn_more"
-
-    within "#navbar-#{@user.id}" do
-      expect(page).to have_link('My Gardens')
-      expect(page).to have_link('My Impact')
-      expect(page).to have_link('Learn More')
-      expect(page).to have_link('Profile')
-      expect(page).to have_link('Logout')
-    end
-  end
-
-  #The test below is currently not working because it needs OAuth to be functioning.  Turns out if you do the ApplicationController shortcut to make :current_user equal @user, then even if you do the destroy action, there isn't really a way to destroy the session, so :current_user is still not nil, so the welcome page won't ever not show the nav bar in this test.  The way around this is to have in the 'before do' the user log in through OAuth or what have you, and then in the test below, have them log out.
-
-  xit "no longer sees my gardens, my impact, learn more, profile and logout on welcome page when not logged in" do
-    visit "/users"
-
-    click_on 'Logout'
-
-    expect(current_path).to eq(root_path)
-
-    expect(page).to_not have_link('My Gardens')
-    expect(page).to_not have_link('My Impact')
-    expect(page).to_not have_link('Learn More')
-    expect(page).to_not have_link('Profile')
-    expect(page).to_not have_link('Logout')
   end
 end

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -203,31 +203,19 @@ RSpec.describe 'Navbar' do
     end
   end
 
-  # Turns out if you do the ApplicationController shortcut to make :current_user equal @user, then even if you do the destroy action, there isn't really a way to log the user out, so :current_user is still not nil, so the welcome page won't ever not show the nav bar in this test.  The way around this is to have in the 'before do' the user log in through OAuth or what have you, and then in the test below, have them log out.  That's not working out however.
   describe "logging in with Login button" do
-    before :each do
-      @user = User.new({id: 4,
-                      attributes: {
-                          email: '123@gmail.com' },
-                      relationships: {
-                          gardens: {
-                              data: [ ] }}})
-      visit root_path
+    it "I can log out" do
+      VCR.use_cassette('google_oauth') do
+        visit root_path
+        stub_omniauth
+        click_link 'Login with Google'
+        click_link 'Logout'
 
-      click_link "Login with Google"
-    end
-
-    it "no longer sees my gardens, my impact, learn more, profile and logout on welcome page when not logged in" do
-
-      click_on 'Logout'
-
-      expect(current_path).to eq(root_path)
-
-      expect(page).to_not have_link('My Gardens')
-      expect(page).to_not have_link('My Impact')
-      expect(page).to_not have_link('Learn More')
-      expect(page).to_not have_link('Profile')
-      expect(page).to_not have_link('Logout')
+        expect(page).to_not have_link('My Gardens')
+        expect(page).to_not have_link('My Impact')
+        expect(page).to_not have_link('Profile')
+        expect(page).to_not have_link('Logout')
+      end
     end
   end
 end

--- a/spec/features/sessions/logout_spec.rb
+++ b/spec/features/sessions/logout_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'Sessions Controller', type: :feature do
+  describe "As a logged in user" do
+    it "I can log out" do
+
+    end
+  end
+end

--- a/spec/features/sessions/logout_spec.rb
+++ b/spec/features/sessions/logout_spec.rb
@@ -3,7 +3,15 @@ require 'rails_helper'
 RSpec.describe 'Sessions Controller', type: :feature do
   describe "As a logged in user" do
     it "I can log out" do
+      VCR.use_cassette('google_oauth') do
+        visit root_path
+        stub_omniauth
+        click_link 'Login with Google'
 
+        click_link 'Logout'
+
+        expect(page).to have_content("You've made an impact today. We hope to see you again tomorrow.")
+      end
     end
   end
 end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe 'Welcome' do
       expect(page).to have_link("Login with Google")
     end
     # We are not sure how to test this quite yet. I think once the OAuth is complete this can be tested.
-    xit "expects to be sent to the Google auth when the button is clicked" do
+    it "expects to be sent to dashboard when the button is clicked/user is logged in" do
       visit root_path
 
       click_link "Login with Google"
-      expect(current_path).to eq('/auth/:provider/callback')
+      expect(current_path).to eq('/dashboard')
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/google_oauth.yml
+++ b/spec/fixtures/vcr_cassettes/google_oauth.yml
@@ -90,4 +90,48 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"id":"2","type":"user","attributes":{"id":2,"email":"john@example.com"},"relationships":{"user_gardens":{"data":[]},"gardens":{"data":[]}}}}'
   recorded_at: Sat, 31 Oct 2020 21:01:50 GMT
+- request:
+    method: get
+    uri: https://solar-garden-be.herokuapp.com/api/v1/users/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 01 Nov 2020 02:27:36 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"2ffd6464deffa12f420210774c62e61c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 227b3c15-9130-43d3-b166-33e232ff1ed5
+      X-Runtime:
+      - '0.009217'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"2","type":"user","attributes":{"id":2,"email":"john@example.com"},"relationships":{"user_gardens":{"data":[]},"gardens":{"data":[]}}}}'
+  recorded_at: Sun, 01 Nov 2020 02:27:36 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
# Navbar/Logout

Go get the basic skeletal structure of the webpages. API calls are not made in this PR.

## View Pages

### ```GET / ``` - welcome

Update Navbar spec to successfully test for not seeing nav bar on welcome page when logged out

### ```GET / logout```

Add logout spec to test logging a user out.
Update the Sessions `destroy` action to log user out.

## Additional Notes

Currently all tests are passing with 98.97% covered. The lines that aren't being hit are lines that will be hit when sensors, users, and plants pages are made.  Also the garden poro needs a test or two