### PR TITLE
User Pages w/ API Calls

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,9 +3,22 @@ class UsersController < ApplicationController
 
   def show; end
 
-  def update; end
+  def update
+    Faraday.patch("#{ENV['BE_URL']}/api/v1/users/#{current_user.id}") do |req|
+      req.headers['CONTENT_TYPE'] = "application/json"
+      req.params['id'] = params[:id].as_json
+      req.params['update_user'] = { email: params[:email] }
+    end
+    redirect_to profile_path
+  end
 
   def destroy
     redirect_to root_path
+  end
+
+  private
+
+  def user_params
+    params.permit(:id, :email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,16 +4,12 @@ class UsersController < ApplicationController
   def show; end
 
   def update
-    Faraday.patch("#{ENV['BE_URL']}/api/v1/users/#{current_user.id}") do |req|
-      req.headers['CONTENT_TYPE'] = "application/json"
-      req.params['id'] = params[:id].as_json
-      req.params['update_user'] = { email: params[:email] }
-    end
+    UserFacade.update_email(current_user.id, params[:email])
     redirect_to profile_path
   end
 
   def destroy
-    Faraday.delete("#{ENV['BE_URL']}/api/v1/users/#{current_user.id}")
+    UserFacade.delete_user(current_user.id)
     session[:user_id] = nil
     flash[:success] = "Successfully deleted account"
     redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,10 @@
 class UsersController < ApplicationController
   before_action :require_user
+
   def show; end
+
   def update; end
+
   def destroy
     redirect_to root_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,9 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    Faraday.delete("#{ENV['BE_URL']}/api/v1/users/#{current_user.id}")
+    session[:user_id] = nil
+    flash[:success] = "Successfully deleted account"
     redirect_to root_path
   end
 

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,0 +1,9 @@
+class UserFacade
+  def self.update_email(id, email)
+    UserService.update_email(id, email)
+  end
+
+  def self.delete_user(id)
+    UserService.delete_user(id)
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,17 @@
+class UserService
+  def self.conn
+    Faraday.new("#{ENV['BE_URL']}")
+  end
+
+  def self.update_email(id, email)
+    conn.patch("/api/v1/users/#{id}") do |req|
+      req.headers['CONTENT_TYPE'] = "application/json"
+      req.params['id'] = id
+      req.params['update_user'] = { email: email }
+    end
+  end
+
+  def self.delete_user(id)
+    conn.delete("/api/v1/users/#{id}")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
       <div class="collapse navbar-collapse navbar-expand-xl" id="collapsibleNavbar">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="<%=gardens_path%>">My Gardens</a>
+            <a class="nav-link" href="<%=dashboard_path%>">My Gardens</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/impact">My Impact</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
         </ul>
         <ul class="nav justify-content-end">
           <li class="nav-item">
-            <a class="nav-link" href="<%=dashboard_path%>">Profile</a>
+            <a class="nav-link" href="<%=profile_path%>">Profile</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="<%=logout_path%>">Logout</a>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,11 @@
+<center>
+  <h3>Update Your Information</h3>
+
+  <section class="new-garden">
+    <%= form_with url: "/users/#{current_user.id}", method: :patch ,local: true do |form| %>
+      <%= form.label :email %><br>
+      <%= form.text_field :email, value: current_user.email, required: true %><br><br>
+      <%= form.submit "Update Information" %><br><br>
+    <% end %>
+  </section>
+</center>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,11 @@
+<section class='profile'>
+  <h1>Your Information</h1>
+
+  <ul>
+    <li class='id'>ID# <%= current_user.id %></li>
+    <li class='email'> Email: <%= current_user.email %></li>
+  </ul>
+
+  <%= button_to 'Delete Profile', "/users/#{current_user.id}", method: :delete %>
+  <p>** Note: Deleting your profile will also delete your gardens and all associated data that have been collected or entered in. Be sure you want to delete before hitting button.</p>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,6 +6,8 @@
     <li class='email'> Email: <%= current_user.email %></li>
   </ul>
 
+  <%= button_to 'Update Profile', edit_user_path(current_user.id), method: :get %>
+  <br><br>
   <%= button_to 'Delete Profile', "/users/#{current_user.id}", method: :delete %>
   <p>** Note: Deleting your profile will also delete your gardens and all associated data that have been collected or entered in. Be sure you want to delete before hitting button.</p>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,14 @@ Rails.application.routes.draw do
 
   get '/auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')
+  get "/logout", to: "sessions#destroy"
   get '/privacy', to: 'privacy#index'
-  resources :users, except: [:index]
   get "/dashboard", to: "dashboard#show"
+  get "/learn_more", to: "learn_more#show"
+  get '/profile', to: 'users#show'
+
+  resources :users, except: [:index, :show]
   resources :gardens, except: [:index]
   resources :plants, except: [:index]
   resources :sensors, except: [:index]
-  get "/learn_more", to: "learn_more#show"
-  get "/logout", to: "sessions#destroy"
 end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'UserFacade' do
+  before :each do
+    @user = User.new({id: 1,
+                    attributes: {
+                        email: '123@gmail.com' },
+                    relationships: {
+                        gardens: {
+                            data: [ { id: 1,
+                                      attributes: {
+                                          name: 'My Garden',
+                                          latitude: 23.0,
+                                          longitude: 24.0,
+                                          description: 'Simple Garden',
+                                          private: false }} ] }}})
+  end
+
+  it 'update_email() returns json of updated information' do
+    expected_output = File.read('spec/fixtures/user_update.json')
+    stub_request(:patch, "#{ENV['BE_URL']}/api/v1/users/#{@user.id}?id=#{@user.id}&update_user%5Bemail%5D=abc@gmail.com").
+         to_return(status: 200, body: expected_output, headers: {})
+    results = UserFacade.update_email(@user.id, 'abc@gmail.com')
+    expect(results).to be_a(Faraday::Response)
+    expect(results.body).to be_a(String)
+    expect(results.body).to_not be_empty
+  end
+
+  it 'delete_user() returns nothing' do
+    stub_request(:delete, "#{ENV['BE_URL']}/api/v1/users/#{@user.id}").
+       to_return(status: 200, body: "", headers: {})
+    results = UserFacade.delete_user(@user.id)
+    expect(results).to be_a(Faraday::Response)
+    expect(results.body).to be_a(String)
+    expect(results.body).to be_empty
+  end
+end

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Navbar' do
     end
 
     it "can see my gardens, my impact, learn more, profile and logout on profile page" do
-      visit "/users/#{@user.id}"
+      visit profile_path
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('My Gardens')

--- a/spec/features/users/destroy_spec.rb
+++ b/spec/features/users/destroy_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'User destroy' do
       visit profile_path
       click_button 'Delete Profile'
       expect(current_path).to eq(root_path)
-      save_and_open_page
     end
   end
 end

--- a/spec/features/users/destroy_spec.rb
+++ b/spec/features/users/destroy_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'User profile page' do
+RSpec.describe 'User destroy' do
   describe 'a user' do
-    it 'can change their email' do
-      @user = User.new({id: 1,
+    it 'can delete their profile' do
+      user = User.new({id: 1,
                       attributes: {
                           email: '123@gmail.com' },
                       relationships: {
@@ -16,16 +16,15 @@ RSpec.describe 'User profile page' do
                                             description: 'Simple Garden',
                                             private: false }} ] }}})
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      expected_output = File.read('spec/fixtures/user_update.json')
-      stub_request(:patch, "https://solar-garden-be.herokuapp.com/api/v1/users/1?id=1&update_user%5Bemail%5D=abc@gmail.com").
-           to_return(status: 200, body: expected_output, headers: {})
+      stub_request(:delete, "#{ENV['BE_URL']}/api/v1/users/#{user.id}").
+         to_return(status: 200, body: "", headers: {})
 
-      visit edit_user_path(@user.id)
-      fill_in :email, with: 'abc@gmail.com'
-      click_button 'Update Information'
-      expect(current_path).to eq(profile_path)
+      visit profile_path
+      click_button 'Delete Profile'
+      expect(current_path).to eq(root_path)
+      save_and_open_page
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'User profile page' do
+  describe 'a user' do
+    it 'can change their email' do
+      @user = User.new({id: 1,
+                      attributes: {
+                          email: '123@gmail.com' },
+                      relationships: {
+                          gardens: {
+                              data: [ { id: 1,
+                                        attributes: {
+                                            name: 'My Garden',
+                                            latitude: 23.0,
+                                            longitude: 24.0,
+                                            description: 'Simple Garden',
+                                            private: false }} ] }}})
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      expected_output = File.read('spec/fixtures/user_update.json')
+      stub_request(:patch, "https://solar-garden-be.herokuapp.com/api/v1/users/1?id=1&update_user%5Bemail%5D=abc@gmail.com").
+           to_return(status: 200, body: expected_output, headers: {})
+           
+      visit edit_user_path(@user.id)
+      fill_in :email, with: 'abc@gmail.com'
+      click_button 'Update Information'
+      expect(current_path).to eq(profile_path)
+    end
+  end
+end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -36,7 +36,14 @@ RSpec.describe 'User profile page' do
       expect(email).to_not be_empty
     end
 
-    it 'has button to delete profile' do
+    it 'has button to update their profile' do
+      visit profile_path
+      expect(page).to have_button('Update Profile')
+      click_button('Update Profile')
+      expect(current_path).to eq(edit_user_path(@user.id))
+    end
+
+    it 'has button to delete their profile' do
       visit profile_path
       expect(page).to have_button('Delete Profile')
     end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'User profile page' do
+  before :each do
+    @user = User.new({id: 1,
+                    attributes: {
+                        email: '123@gmail.com' },
+                    relationships: {
+                        gardens: {
+                            data: [ { id: 1,
+                                      attributes: {
+                                          name: 'My Garden',
+                                          latitude: 23.0,
+                                          longitude: 24.0,
+                                          description: 'Simple Garden',
+                                          private: false }} ] }}})
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+  end
+
+  describe 'a user' do
+    it 'can visit their profile page' do
+      visit profile_path
+    end
+
+    it 'displays relevant user information' do
+      visit profile_path
+
+      expect(page).to have_content('Your Information')
+
+      expect(page).to have_css('.id')
+      id = find('.id').text
+      expect(id).to_not be_empty
+      expect(page).to have_css('.email')
+      email = find('.email').text
+      expect(email).to_not be_empty
+    end
+
+    it 'has button to delete profile' do
+      visit profile_path
+      expect(page).to have_button('Delete Profile')
+    end
+  end
+end

--- a/spec/fixtures/user_update.json
+++ b/spec/fixtures/user_update.json
@@ -1,0 +1,52 @@
+{
+    "data": {
+        "id": "1",
+        "type": "user",
+        "attributes": {
+            "id": 1,
+            "email": "abc@gmail.com"
+        },
+        "relationships": {
+            "user_gardens": {
+                "data": [
+                    {
+                        "id": "2",
+                        "type": "user_garden"
+                    },
+                    {
+                        "id": "3",
+                        "type": "user_garden"
+                    },
+                    {
+                        "id": "4",
+                        "type": "user_garden"
+                    },
+                    {
+                        "id": "5",
+                        "type": "user_garden"
+                    }
+                ]
+            },
+            "gardens": {
+                "data": [
+                    {
+                        "id": "9",
+                        "type": "garden"
+                    },
+                    {
+                        "id": "10",
+                        "type": "garden"
+                    },
+                    {
+                        "id": "11",
+                        "type": "garden"
+                    },
+                    {
+                        "id": "12",
+                        "type": "garden"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'UserService' do
+  before :each do
+    @user = User.new({id: 1,
+                    attributes: {
+                        email: '123@gmail.com' },
+                    relationships: {
+                        gardens: {
+                            data: [ { id: 1,
+                                      attributes: {
+                                          name: 'My Garden',
+                                          latitude: 23.0,
+                                          longitude: 24.0,
+                                          description: 'Simple Garden',
+                                          private: false }} ] }}})
+  end
+
+  it 'update_email() returns json of updated information' do
+    expected_output = File.read('spec/fixtures/user_update.json')
+    stub_request(:patch, "#{ENV['BE_URL']}/api/v1/users/#{@user.id}?id=#{@user.id}&update_user%5Bemail%5D=abc@gmail.com").
+         to_return(status: 200, body: expected_output, headers: {})
+    results = UserService.update_email(@user.id, 'abc@gmail.com')
+    expect(results).to be_a(Faraday::Response)
+    expect(results.body).to be_a(String)
+    expect(results.body).to_not be_empty
+  end
+
+  it 'delete_user() returns nothing' do
+    stub_request(:delete, "#{ENV['BE_URL']}/api/v1/users/#{@user.id}").
+       to_return(status: 200, body: "", headers: {})
+    results = UserService.delete_user(@user.id)
+    expect(results).to be_a(Faraday::Response)
+    expect(results.body).to be_a(String)
+    expect(results.body).to be_empty
+  end
+end


### PR DESCRIPTION
Creates view pages for:

- User profile via ```/profile``` or ```profile_path```
- User edit page via ```/profile/:id/edit``` or ```edit_user_path```

The user has the ability to delete their profile as well with a button on their profile page. 

All calls are web-mocked. Using environment variable BE_URL for the base url to the back end app on heroku.