### PR TITLE
Create new garden

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,15 +7,15 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
-  def require_user
-    render file: "/public/404" unless current_user
-  end
-
   def render_404
     respond_to do |format|
       format.html { render :file => "#{Rails.root}/public/404", :layout => false, :status => :not_found }
       format.xml  { head :not_found }
       format.any  { head :not_found }
     end
+  end
+
+  def require_user
+    render_404 unless current_user
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,7 @@
 class DashboardController < ApplicationController
   before_action :require_user
   
-  def show; end
+  def show
+    @gardens = GardenFacade.create_garden_objects(current_user.gardens)
+  end
 end

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -2,7 +2,7 @@ class GardensController < ApplicationController
   before_action :require_user, except: [:show]
 
   def index
-    # right now, gardens are rendering based on user's gardens in json relationship hash. Could turn those into actual garden objects here but wasn't sure if that would impact performance.
+    @gardens = GardenFacade.create_garden_objects(current_user.gardens)
   end
 
   def show
@@ -27,7 +27,7 @@ class GardensController < ApplicationController
     # GET "api/v1/gardens/params[:id]" to obtain garden from id
 
               # this code is used only for testing
-    @garden = Garden.new(current_user.gardens.first)
+  @garden = Garden.new(current_user.gardens.first)
   end
 
   def update

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -18,7 +18,7 @@ class GardensController < ApplicationController
   def create
     # POST "api/v1/gardens" to create a garden using strong params
     # note pass in current_user.id into hash for back-end association
-    redirect_to dashboard_path
+    redirect_to gardens_path
   end
 
   def edit
@@ -30,12 +30,12 @@ class GardensController < ApplicationController
 
   def update
     # PATCH "api/v1/gardens/params[:id]" to update the garden using strong params
-    redirect_to dashboard_path
+    redirect_to gardens_path
   end
 
   def destroy
     # DELETE api/v1/gardens/:id' to destroy garden
-    redirect_to dashboard_path
+    redirect_to gardens_path
   end
 
   private
@@ -45,6 +45,6 @@ class GardensController < ApplicationController
   end
 
   def current_users_garden?(garden)
-      garden.user_ids.include?(current_user.id.to_s) if current_user
+    garden.user_ids.include?(current_user.id.to_s) if current_user
   end
 end

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,7 +1,9 @@
 class GardensController < ApplicationController
   before_action :require_user, except: [:show]
 
-  def index; end
+  def index
+    # right now, gardens are rendering based on user's gardens in json relationship hash. Could turn those into actual garden objects here but wasn't sure if that would impact performance.
+  end
 
   def show
     garden = GardenFacade.garden_details(params)

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,9 +1,9 @@
 class GardensController < ApplicationController
   before_action :require_user, except: [:show]
 
-  def index
-    @gardens = GardenFacade.create_garden_objects(current_user.gardens)
-  end
+  # def index
+  #   @gardens = GardenFacade.create_garden_objects(current_user.gardens)
+  # end
 
   def show
     garden = GardenFacade.garden_details(params)
@@ -20,7 +20,7 @@ class GardensController < ApplicationController
 
   def create
     GardenFacade.new_garden(garden_params, current_user.id)
-    redirect_to gardens_path
+    redirect_to dashboard_path
   end
 
   def edit
@@ -29,7 +29,7 @@ class GardensController < ApplicationController
 
   def update
     # PATCH "api/v1/gardens/params[:id]" to update the garden using strong params
-    redirect_to gardens_path
+    redirect_to dashboard_path
   end
 
   def destroy

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -24,10 +24,7 @@ class GardensController < ApplicationController
   end
 
   def edit
-    # GET "api/v1/gardens/params[:id]" to obtain garden from id
-
-              # this code is used only for testing
-  @garden = Garden.new(current_user.gardens.first)
+    @garden = GardenFacade.garden_details(params)
   end
 
   def update

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,6 +1,7 @@
 class GardensController < ApplicationController
   before_action :require_user, except: [:show]
 
+  def index; end
 
   def show
     garden = GardenFacade.garden_details(params)
@@ -16,8 +17,7 @@ class GardensController < ApplicationController
   def new; end
 
   def create
-    # POST "api/v1/gardens" to create a garden using strong params
-    # note pass in current_user.id into hash for back-end association
+    GardenFacade.new_garden(garden_params, current_user.id)
     redirect_to gardens_path
   end
 

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -35,7 +35,7 @@ class GardensController < ApplicationController
 
   def destroy
     # DELETE api/v1/gardens/:id' to destroy garden
-    redirect_to gardens_path
+    redirect_back(fallback_location: dashboard_path)
   end
 
   private

--- a/app/facades/garden_facade.rb
+++ b/app/facades/garden_facade.rb
@@ -1,7 +1,7 @@
 class GardenFacade
   def self.create_garden_objects(users_gardens) 
     users_gardens.map do |garden|
-      response = garden_details(garden)
+      garden_details(garden)
     end
   end
 

--- a/app/facades/garden_facade.rb
+++ b/app/facades/garden_facade.rb
@@ -1,4 +1,10 @@
 class GardenFacade
+  def self.create_garden_objects(users_gardens)
+    users_gardens.map do |garden|
+      garden_details(garden)
+    end
+  end
+
   def self.garden_details(params)
     parsed_json = GardenService.garden_details(params)
     garden(parsed_json)

--- a/app/facades/garden_facade.rb
+++ b/app/facades/garden_facade.rb
@@ -7,4 +7,8 @@ class GardenFacade
   def self.garden(data)
     Garden.new(data[:data])
   end
+
+  def self.new_garden(params, current_user_id)
+    GardenService.new_garden(params, current_user_id)
+  end
 end

--- a/app/facades/garden_facade.rb
+++ b/app/facades/garden_facade.rb
@@ -1,7 +1,7 @@
 class GardenFacade
-  def self.create_garden_objects(users_gardens)
+  def self.create_garden_objects(users_gardens) 
     users_gardens.map do |garden|
-      garden_details(garden)
+      response = garden_details(garden)
     end
   end
 

--- a/app/services/garden_service.rb
+++ b/app/services/garden_service.rb
@@ -3,6 +3,11 @@ class GardenService
     get_parsed_json("api/v1/gardens/#{params[:id]}")
   end
 
+  def self.new_garden(params, current_user_id)
+    response = conn.post("api/v1/gardens?user_id=#{current_user_id}&longitude=#{params[:longitude]}&latitude=#{params[:latitude]}&name=#{params[:name]}&private=#{params[:private]}&description=#{params[:description]}")
+    JSON.parse(response.body)
+  end
+
   def self.get_parsed_json(url, params = {})
     response = conn.get(url) do |req|
       req.params = params

--- a/app/services/garden_service.rb
+++ b/app/services/garden_service.rb
@@ -5,7 +5,7 @@ class GardenService
 
   def self.new_garden(params, current_user_id)
     response = conn.post("api/v1/gardens?user_id=#{current_user_id}&longitude=#{params[:longitude]}&latitude=#{params[:latitude]}&name=#{params[:name]}&private=#{params[:private]}&description=#{params[:description]}")
-    JSON.parse(response.body)
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.get_parsed_json(url, params = {})

--- a/app/services/garden_service.rb
+++ b/app/services/garden_service.rb
@@ -1,10 +1,10 @@
 class GardenService
   def self.garden_details(params)
-    get_parsed_json("api/v1/gardens/#{params[:id]}")
+    get_parsed_json("/api/v1/gardens/#{params[:id]}")
   end
 
   def self.new_garden(params, current_user_id)
-    response = conn.post("api/v1/gardens") do |req|
+    response = conn.post("/api/v1/gardens") do |req|
       req.params = params
       req.params[:user_id] = current_user_id
     end
@@ -19,6 +19,6 @@ class GardenService
   end
 
   def self.conn
-    Faraday.new(url: 'https://solar-garden-be.herokuapp.com/')
+    Faraday.new(url: "#{ENV['BE_URL']}")
   end
 end

--- a/app/services/garden_service.rb
+++ b/app/services/garden_service.rb
@@ -4,7 +4,10 @@ class GardenService
   end
 
   def self.new_garden(params, current_user_id)
-    response = conn.post("api/v1/gardens?user_id=#{current_user_id}&longitude=#{params[:longitude]}&latitude=#{params[:latitude]}&name=#{params[:name]}&private=#{params[:private]}&description=#{params[:description]}")
+    response = conn.post("api/v1/gardens") do |req|
+      req.params = params
+      req.params[:user_id] = current_user_id
+    end
     JSON.parse(response.body, symbolize_names: true)
   end
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,21 +1,3 @@
-<center>
-  <article class='gardens'>
-    <% if current_user.gardens.empty? %>
-      <h5>You have no gardens</h5>
-    <% else %>
-      <% current_user.gardens.each do |garden| %>
-        <section class='garden' id='garden-<%= garden[:id] %>'>
-          <div class='garden-image'>
-            <%= link_to image_tag('default-garden.png'), "/gardens/#{garden[:id]}" %>
-          </div>
-          <div class="garden-buttons">
-            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden[:id]), class: 'garden-button', alt: 'edit-garden' %>
-            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden[:id]}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
-          </div>
-        </section>
-      <% end %>
-    <% end %>
+<h1>My Dashboard</h1>
 
-    <%= button_to 'Add New Garden', new_garden_path, method: :get %>
-  </article>
-</center>
+<%= render 'shared/users_gardens_index' %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -1,3 +1,0 @@
-<h1>My Gardens</h1>
-
-<%= render 'shared/users_gardens_index' %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -7,9 +7,16 @@
     <% else %>
       <% current_user.gardens.each do |garden| %>
         <section class='garden' id='garden-<%= garden[:id] %>'>
-          <div class='garden-image'>
+          <h3><%= garden[:attributes][:name] %></h3>
+          <div class='garden-image'>  
             <%= image_tag 'default-garden.png' %>
           </div>
+          <ul>
+            <li>Description: <%= garden[:attributes][:description] %></li>
+            <li>Latitude: <%= garden[:attributes][:latitude] %></li>
+            <li>Longitude: <%= garden[:attributes][:longitude] %></li>
+            <li>Private? <%= garden[:attributes][:private] %></li>
+          </ul>
           <div class="garden-buttons">
             <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden[:id]), class: 'garden-button', alt: 'edit-garden' %>
             <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden[:id]}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -1,0 +1,23 @@
+<h1>My Gardens</h1>
+
+<center>
+  <article class='gardens'>
+    <% if current_user.gardens.empty? %>
+      <h5>You have no gardens</h5>
+    <% else %>
+      <% current_user.gardens.each do |garden| %>
+        <section class='garden' id='garden-<%= garden[:id] %>'>
+          <div class='garden-image'>
+            <%= image_tag 'default-garden.png' %>
+          </div>
+          <div class="garden-buttons">
+            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden[:id]), class: 'garden-button', alt: 'edit-garden' %>
+            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden[:id]}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
+          </div>
+        </section>
+      <% end %>
+    <% end %>
+
+    <%= button_to 'Add New Garden', new_garden_path, method: :get %>
+  </article>
+</center>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -5,21 +5,21 @@
     <% if current_user.gardens.empty? %>
       <h5>You have no gardens</h5>
     <% else %>
-      <% current_user.gardens.each do |garden| %>
-        <section class='garden' id='garden-<%= garden[:id] %>'>
-          <h3><%= garden[:attributes][:name] %></h3>
+      <% @gardens.each do |garden| %>
+        <section class='garden' id='garden-<%= garden.id %>'>
+          <h3><%= garden.name %></h3>
           <div class='garden-image'>  
             <%= image_tag 'default-garden.png' %>
           </div>
           <ul>
-            <li>Description: <%= garden[:attributes][:description] %></li>
-            <li>Latitude: <%= garden[:attributes][:latitude] %></li>
-            <li>Longitude: <%= garden[:attributes][:longitude] %></li>
-            <li>Private? <%= garden[:attributes][:private] %></li>
+            <li>Description: <%= garden.description %></li>
+            <li>Latitude: <%= garden.latitude %></li>
+            <li>Longitude: <%= garden.longitude %></li>
+            <li>Private? <%= garden.is_private %></li>
           </ul>
           <div class="garden-buttons">
-            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden[:id]), class: 'garden-button', alt: 'edit-garden' %>
-            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden[:id]}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
+            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden.id), class: 'garden-button', alt: 'edit-garden' %>
+            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden.id}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
           </div>
         </section>
       <% end %>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -1,30 +1,3 @@
 <h1>My Gardens</h1>
 
-<center>
-  <article class='gardens'>
-    <% if current_user.gardens.empty? %>
-      <h5>You have no gardens</h5>
-    <% else %>
-      <% @gardens.each do |garden| %>
-        <section class='garden' id='garden-<%= garden.id %>'>
-          <h3><%= garden.name %></h3>
-          <div class='garden-image'>  
-            <%= image_tag 'default-garden.png' %>
-          </div>
-          <ul>
-            <li>Description: <%= garden.description %></li>
-            <li>Latitude: <%= garden.latitude %></li>
-            <li>Longitude: <%= garden.longitude %></li>
-            <li>Private? <%= garden.is_private %></li>
-          </ul>
-          <div class="garden-buttons">
-            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden.id), class: 'garden-button', alt: 'edit-garden' %>
-            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden.id}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
-          </div>
-        </section>
-      <% end %>
-    <% end %>
-
-    <%= button_to 'Add New Garden', new_garden_path, method: :get %>
-  </article>
-</center>
+<%= render 'shared/users_gardens_index' %>

--- a/app/views/gardens/new.html.erb
+++ b/app/views/gardens/new.html.erb
@@ -2,7 +2,7 @@
   <h3>Create A New Garden</h3>
 
   <section class="new-garden">
-    <%= form_with url: '/gardens', local: true do |form| %>
+    <%= form_with method: :post, url: '/gardens', local: true do |form| %>
       <%= form.label :name %><br>
       <%= form.text_field :name, placeholder: 'Tomato Garden', required: true %><br><br>
       <%= form.label :latitude %><br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
       <div class="collapse navbar-collapse navbar-expand-xl" id="collapsibleNavbar">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="<%=dashboard_path%>">My Gardens</a>
+            <a class="nav-link" href="<%=dashboard_path%>">Dashboard</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/impact">My Impact</a>

--- a/app/views/shared/_users_gardens_index.html.erb
+++ b/app/views/shared/_users_gardens_index.html.erb
@@ -16,8 +16,8 @@
             <li>Private? <%= garden.is_private %></li>
           </ul>
           <div class="garden-buttons">
-            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden.id), class: 'garden-button', alt: 'edit-garden' %>
-            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden.id}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
+            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden.id), class: 'garden-button edit-button', alt: 'edit-garden' %>
+            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden.id}", method: :delete, class: 'garden-button delete-button', alt: 'delete-garden' %>
           </div>
         </section>
       <% end %>

--- a/app/views/shared/_users_gardens_index.html.erb
+++ b/app/views/shared/_users_gardens_index.html.erb
@@ -1,0 +1,28 @@
+<center>
+  <article class='gardens'>
+    <% if current_user.gardens.empty? %>
+      <h5>You have no gardens</h5>
+    <% else %>
+      <% @gardens.each do |garden| %>
+        <section class='garden' id='garden-<%= garden.id %>'>
+          <h3><%= garden.name %></h3>
+          <div class='garden-image'>  
+            <%= image_tag 'default-garden.png' %>
+          </div>
+          <ul>
+            <li>Description: <%= garden.description %></li>
+            <li>Latitude: <%= garden.latitude %></li>
+            <li>Longitude: <%= garden.longitude %></li>
+            <li>Private? <%= garden.is_private %></li>
+          </ul>
+          <div class="garden-buttons">
+            <%= link_to image_tag('edit-garden.png'), edit_garden_path(garden.id), class: 'garden-button', alt: 'edit-garden' %>
+            <%= link_to image_tag('trash-garden.png'), "/gardens/#{garden.id}", method: :delete, class: 'garden-button', alt: 'delete-garden' %>
+          </div>
+        </section>
+      <% end %>
+    <% end %>
+
+    <%= button_to 'Add New Garden', new_garden_path, method: :get %>
+  </article>
+</center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/privacy', to: 'privacy#index'
   resources :users, except: [:index]
   get "/dashboard", to: "dashboard#show"
-  resources :gardens, except: [:index]
+  resources :gardens
   resources :plants, except: [:index]
   resources :sensors, except: [:index]
   get "/learn_more", to: "learn_more#show"

--- a/spec/facades/garden_facade_spec.rb
+++ b/spec/facades/garden_facade_spec.rb
@@ -25,47 +25,6 @@ describe GardenFacade do
     stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{params[:description]}&latitude=#{params[:latitude]}&longitude=#{params[:longitude]}&name=#{params[:name]}&private=false&user_id=1").to_return(status: 200, body: expected_output, headers: {})
 
     response = GardenFacade.new_garden(params.symbolize_keys, "1")
-
-    expect(response).to have_key(:data)
-    expect(response[:data]).to be_a(Hash)
-
-    expect(response[:data]).to have_key(:id)
-    expect(response[:data][:id]).to be_a(String)
-
-    expect(response[:data]).to have_key(:type)
-    expect(response[:data][:type]).to be_a(String)
-
-    expect(response[:data]).to have_key(:attributes)
-    expect(response[:data][:attributes]).to be_a(Hash)
-
-    expect(response[:data][:attributes]).to have_key(:latitude)
-    expect(response[:data][:attributes][:latitude]).to be_a(Float)
-
-    expect(response[:data][:attributes]).to have_key(:longitude)
-    expect(response[:data][:attributes][:longitude]).to be_a(Float)
-
-    expect(response[:data][:attributes]).to have_key(:name)
-    expect(response[:data][:attributes][:name]).to be_a(String)
-
-    expect(response[:data][:attributes]).to have_key(:description)
-    expect(response[:data][:attributes][:description]).to be_a(String)
-
-    expect(response[:data][:attributes]).to have_key(:private)
-    expect(response[:data][:attributes][:private]).to be_in([true, false])
-
-    expect(response[:data]).to have_key(:relationships)
-    expect(response[:data][:relationships]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:user_gardens)
-    expect(response[:data][:relationships][:user_gardens]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:users)
-    expect(response[:data][:relationships][:users]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:sensors)
-    expect(response[:data][:relationships][:sensors]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:garden_plants)
-    expect(response[:data][:relationships][:garden_plants]).to be_a(Hash)
+    garden_details_response_structure_check(response)
   end
 end

--- a/spec/facades/garden_facade_spec.rb
+++ b/spec/facades/garden_facade_spec.rb
@@ -17,4 +17,55 @@ describe GardenFacade do
 
     garden = GardenFacade.garden(data)
   end
+
+  it "can create a new garden (no need to return as garden object)" do
+    params = {"name"=>"The Grove", "latitude"=>"71.0", "longitude"=>"25.0", "private"=>"false", "description"=>"My first garden"}
+    
+    expected_output = File.read('spec/fixtures/new_garden.json')
+    stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{params[:description]}&latitude=#{params[:latitude]}&longitude=#{params[:longitude]}&name=#{params[:name]}&private=false&user_id=1").to_return(status: 200, body: expected_output, headers: {})
+
+    response = GardenFacade.new_garden(params.symbolize_keys, "1")
+
+    expect(response).to have_key(:data)
+    expect(response[:data]).to be_a(Hash)
+
+    expect(response[:data]).to have_key(:id)
+    expect(response[:data][:id]).to be_a(String)
+
+    expect(response[:data]).to have_key(:type)
+    expect(response[:data][:type]).to be_a(String)
+
+    expect(response[:data]).to have_key(:attributes)
+    expect(response[:data][:attributes]).to be_a(Hash)
+
+    expect(response[:data][:attributes]).to have_key(:latitude)
+    expect(response[:data][:attributes][:latitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:longitude)
+    expect(response[:data][:attributes][:longitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:name)
+    expect(response[:data][:attributes][:name]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:description)
+    expect(response[:data][:attributes][:description]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:private)
+    expect(response[:data][:attributes][:private]).to be_in([true, false])
+
+    expect(response[:data]).to have_key(:relationships)
+    expect(response[:data][:relationships]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:user_gardens)
+    expect(response[:data][:relationships][:user_gardens]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:users)
+    expect(response[:data][:relationships][:users]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:sensors)
+    expect(response[:data][:relationships][:sensors]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:garden_plants)
+    expect(response[:data][:relationships][:garden_plants]).to be_a(Hash)
+  end
 end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -59,21 +59,20 @@ RSpec.describe 'User Dashboard' do
       end
     end
 
-    xit 'has an image to edit and delete a garden' do
+    it 'has an image to edit and delete a garden' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_gardens)
 
- 
       visit dashboard_path
 
       within '#garden-3' do
-        find(:xpath, "//a[contains(@alt, 'edit-garden')]").click
+        find('.edit-button').click
       end
 
       expect(current_path).to eq("/gardens/3/edit")
       visit dashboard_path
 
       within '#garden-4' do
-        find(:xpath, "//a[contains(@alt, 'delete-garden')]").click
+        find('.delete-button').click
       end
       expect(current_path).to eq(dashboard_path)
     end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe 'User Dashboard' do
         find(:xpath, "//a[contains(@alt, 'delete-garden')]").click
       end
       expect(current_path).to eq(dashboard_path)
-
     end
   end
 

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe 'Edit Garden Page' do
       expect(page).to have_button('Update Garden')
     end
 
-    it 'fills new garden form, submits and is redirected to gardens index' do
+    it 'fills in edit garden form, submits and is redirected to garden show page' do
       visit "/gardens/#{@garden[:id]}/edit"
       fill_in :name, with: 'Test'
       fill_in :longitude, with: 25.0000
       fill_in :latitude, with: 71.0000
       fill_in :description, with: 'My first garden'
       click_button 'Update Garden'
-      expect(current_path).to eq(gardens_path)
+      expect(current_path).to eq(dashboard_path)
     end
   end
 end

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe 'Edit Garden Page' do
       expect(page).to have_button('Update Garden')
     end
 
-    it 'fills new garden form, submits and is redirect back to dashboard' do
+    it 'fills new garden form, submits and is redirected to gardens index' do
       visit "/gardens/#{@garden[:id]}/edit"
       fill_in :name, with: 'Test'
       fill_in :longitude, with: 25.0000
       fill_in :latitude, with: 71.0000
       fill_in :description, with: 'My first garden'
       click_button 'Update Garden'
-      expect(current_path).to eq(dashboard_path)
+      expect(current_path).to eq(gardens_path)
     end
   end
 end

--- a/spec/features/gardens/edit_spec.rb
+++ b/spec/features/gardens/edit_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 RSpec.describe 'Edit Garden Page' do
   describe 'a logged in user' do
     before :each do
-      @garden = { id: 1,
+      @garden = { id: 3,
                 attributes: {
-                    name: 'My Garden',
-                    latitude: 23.0,
-                    longitude: 24.0,
-                    description: 'Simple Garden',
+                    name: "Cole Community Garden",
+                    latitude: 39.45,
+                    longitude: -104.58,
+                    description: "A diverse, dedicated group of students and neighbors who believe in bettering ourselves, our food supply and our community through urban gardening.",
                     private: false },
                 relationships: { plants: {
                                     data: []},
                                   users: {
-                                    data: [{id: "1", type: "user"}]},
+                                    data: [{id: "4", type: "user"}]},
                                  sensors: {
                                     data: []}}}
 
-      @user = User.new({id: 1,
+      @user = User.new({id: 4,
                       attributes: {
                           email: '123@gmail.com' },
                       relationships: {
@@ -25,6 +25,9 @@ RSpec.describe 'Edit Garden Page' do
                               data: [ @garden ] }}})
 
       @garden = @user.gardens.first
+
+      garden1 = File.read('spec/fixtures/public_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/3").to_return(status: 200, body: garden1)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
@@ -35,9 +38,10 @@ RSpec.describe 'Edit Garden Page' do
 
     it 'sees four input fields, two radio buttons and a button to submit' do
       visit "/gardens/#{@garden[:id]}/edit"
-      expect(page).to have_selector("input[value='#{@garden[:attributes][:name]}']")
-      expect(page).to have_selector("input[value='#{@garden[:attributes][:latitude]}']")
-      expect(page).to have_selector("input[value='#{@garden[:attributes][:longitude]}']")
+
+      expect(find_field(:name).value).to eq("#{@garden[:attributes][:name]}")
+      expect(find_field(:latitude).value).to eq("#{@garden[:attributes][:latitude]}")
+      expect(find_field(:longitude).value).to eq("#{@garden[:attributes][:longitude]}")
       expect(page).to have_selector("input[id='private_true']")
       expect(page).to have_selector("input[id='private_false']")
       expect(page).to have_button('Update Garden')

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'New Garden Page' do
       expect(page).to have_button('Create Garden')
     end
 
-    it 'fills new garden form, submits and is redirected to garden index' do
+    it 'fills new garden form, submits and is redirected to dashboard' do
       name = 'The Grove'
       longitude = 25.0000
       latitude = 71.0000
@@ -54,10 +54,9 @@ RSpec.describe 'New Garden Page' do
             data: [ {id: '50', type: 'garden'}] }}})
             
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_garden)
-
       click_button 'Create Garden'
 
-      expect(current_path).to eq(gardens_path)
+      expect(current_path).to eq(dashboard_path)
       expect(page).to have_content(name)
       expect(page).to have_content(description)
       expect(page).to have_content(longitude)

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -8,13 +8,7 @@ RSpec.describe 'New Garden Page' do
                           email: '123@gmail.com' },
                       relationships: {
                           gardens: {
-                              data: [ { id: 1,
-                                        attributes: {
-                                            name: 'My Garden',
-                                            latitude: 23.0,
-                                            longitude: 24.0,
-                                            description: 'Simple Garden',
-                                            private: false }} ] }}})
+                              data: [] }}})
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
@@ -34,18 +28,40 @@ RSpec.describe 'New Garden Page' do
     end
 
     it 'fills new garden form, submits and is redirected to garden index' do
+      name = 'The Grove'
+      longitude = 25.0000
+      latitude = 71.0000
+      description = 'My first garden'
+
       visit new_garden_path
-      fill_in :name, with: 'Test'
-      fill_in :longitude, with: 25.0000
-      fill_in :latitude, with: 71.0000
+      fill_in :name, with: name
+      fill_in :longitude, with: longitude
+      fill_in :latitude, with: latitude
       fill_in :description, with: 'My first garden'
+
+      @user_with_garden = User.new({id: 1,
+      attributes: {
+          email: '123@gmail.com' },
+      relationships: {
+          gardens: {
+              data: [ { id: 1,
+                        attributes: {
+                            name: name,
+                            latitude: latitude,
+                            longitude: longitude,
+                            description: description,
+                            private: false }} ] }}})
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_garden)
+      
       click_button 'Create Garden'
 
       expect(current_path).to eq(gardens_path)
-      expect(page).to have_content('The Grove')
-      expect(page).to have_content('My first garden')
-      expect(page).to have_content(25.000)
-      expect(page).to have_content(71.000)
+      expect(page).to have_content(name)
+      expect(page).to have_content(description)
+      expect(page).to have_content(longitude)
+      expect(page).to have_content(latitude)
+      expect(page).to have_content(false)
     end
   end
 end

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe 'New Garden Page' do
       description = 'My first garden'
 
       expected_output = File.read('spec/fixtures/new_garden.json')
+
       stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{description}&latitude=#{latitude}&longitude=#{longitude}&name=#{name}&private=false&user_id=#{@user.id}").to_return(status: 200, body: expected_output, headers: {})
+
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/50").to_return(status: 200, body: expected_output, headers: {})
 
       visit new_garden_path
       fill_in :name, with: name
@@ -42,22 +45,16 @@ RSpec.describe 'New Garden Page' do
       fill_in :latitude, with: latitude
       fill_in :description, with: 'My first garden'
       find('#private_false').click
-
+      
       @user_with_garden = User.new({id: 1,
       attributes: {
-          email: '123@gmail.com' },
-      relationships: {
+        email: '123@gmail.com' },
+        relationships: {
           gardens: {
-              data: [ { id: 1,
-                        attributes: {
-                            name: name,
-                            latitude: latitude,
-                            longitude: longitude,
-                            description: description,
-                            private: false }} ] }}})
-
+            data: [ {id: '50', type: 'garden'}] }}})
+            
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_garden)
-      
+
       click_button 'Create Garden'
 
       expect(current_path).to eq(gardens_path)

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe 'New Garden Page' do
       latitude = 71.0000
       description = 'My first garden'
 
+      expected_output = File.read('spec/fixtures/new_garden.json')
+      stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{description}&latitude=#{latitude}&longitude=#{longitude}&name=#{name}&private=false&user_id=#{@user.id}").to_return(status: 200, body: expected_output, headers: {})
+
       visit new_garden_path
       fill_in :name, with: name
       fill_in :longitude, with: longitude

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'New Garden Page' do
       fill_in :longitude, with: longitude
       fill_in :latitude, with: latitude
       fill_in :description, with: 'My first garden'
+      find('#private_false').click
 
       @user_with_garden = User.new({id: 1,
       attributes: {

--- a/spec/features/gardens/new_spec.rb
+++ b/spec/features/gardens/new_spec.rb
@@ -33,14 +33,19 @@ RSpec.describe 'New Garden Page' do
       expect(page).to have_button('Create Garden')
     end
 
-    it 'fills new garden form, submits and is redirect back to dashboard' do
+    it 'fills new garden form, submits and is redirected to garden index' do
       visit new_garden_path
       fill_in :name, with: 'Test'
       fill_in :longitude, with: 25.0000
       fill_in :latitude, with: 71.0000
       fill_in :description, with: 'My first garden'
       click_button 'Create Garden'
-      expect(current_path).to eq(dashboard_path)
+
+      expect(current_path).to eq(gardens_path)
+      expect(page).to have_content('The Grove')
+      expect(page).to have_content('My first garden')
+      expect(page).to have_content(25.000)
+      expect(page).to have_content(71.000)
     end
   end
 end

--- a/spec/features/learn_more/show_spec.rb
+++ b/spec/features/learn_more/show_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Learn More page' do
     end
 
     it "a logged in user can see a navbar" do
-      expect(page).to have_link("My Gardens")
+      expect(page).to have_link("Dashboard")
       expect(page).to have_link("My Impact")
       expect(page).to have_link("Learn More")
       expect(page).to have_link("Logout")

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe 'Navbar' do
       stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/#{@garden[:id]}").to_return(status: 200, body: response)
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on profile page" do
+    it "can see my dash, my impact, learn more, profile and logout on profile page" do
       visit profile_path
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -73,11 +73,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on dashboard" do
+    it "can see my dash, my impact, learn more, profile and logout on dashboard" do
       visit "/dashboard"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -85,11 +85,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on garden show page" do
+    it "can see my dash, my impact, learn more, profile and logout on garden show page" do
       visit "/gardens/#{@garden[:id]}"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -97,11 +97,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on garden update page" do
+    it "can see my dash, my impact, learn more, profile and logout on garden update page" do
       visit "/gardens/#{@garden[:id]}/edit"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -109,11 +109,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on create garden page" do
+    it "can see my dash, my impact, learn more, profile and logout on create garden page" do
       visit "/gardens/new"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -121,11 +121,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on plant show page" do
+    it "can see my dash, my impact, learn more, profile and logout on plant show page" do
       visit "/plants/#{@plant.id}"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -133,11 +133,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on plant new page" do
+    it "can see my dash, my impact, learn more, profile and logout on plant new page" do
       visit "/plants/new"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -145,11 +145,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on plant update page" do
+    it "can see my dash, my impact, learn more, profile and logout on plant update page" do
       visit "/plants/update"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -157,11 +157,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on sensor show page" do
+    it "can see my dash, my impact, learn more, profile and logout on sensor show page" do
       visit "/sensors/#{@sensor.id}"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -169,11 +169,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on sensor new page" do
+    it "can see my dash, my impact, learn more, profile and logout on sensor new page" do
       visit "/sensors/new"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -181,11 +181,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on sensor update page" do
+    it "can see my dash, my impact, learn more, profile and logout on sensor update page" do
       visit "/sensors/update"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
@@ -193,11 +193,11 @@ RSpec.describe 'Navbar' do
       end
     end
 
-    it "can see my gardens, my impact, learn more, profile and logout on learn more page" do
+    it "can see my dash, my impact, learn more, profile and logout on learn more page" do
       visit "/learn_more"
 
       within "#navbar-#{@user.id}" do
-        expect(page).to have_link('My Gardens')
+        expect(page).to have_link('Dashboard')
         expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')

--- a/spec/fixtures/new_garden.json
+++ b/spec/fixtures/new_garden.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+      "id": "50",
+      "type": "garden",
+      "attributes": {
+          "latitude": 71.0,
+          "longitude": 25.0,
+          "name": "The Grove",
+          "description": "My first garden",
+          "private": false
+      },
+      "relationships": {
+          "user_gardens": {
+              "data": [
+                  {
+                      "id": "43",
+                      "type": "user_garden"
+                  }
+              ]
+          },
+          "users": {
+              "data": [
+                  {
+                      "id": "1",
+                      "type": "user"
+                  }
+              ]
+          },
+          "sensors": {
+              "data": []
+          },
+          "garden_plants": {
+              "data": []
+          },
+          "plants": {
+              "data": []
+          }
+      }
+  }
+}

--- a/spec/fixtures/new_garden.json
+++ b/spec/fixtures/new_garden.json
@@ -15,7 +15,7 @@
                   {
                       "id": "43",
                       "type": "user_garden"
-                  }
+                }
               ]
           },
           "users": {

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,45 @@
+module Helpers
+  def garden_details_response_structure_check(response)
+    expect(response).to have_key(:data)
+    expect(response[:data]).to be_a(Hash)
+
+    expect(response[:data]).to have_key(:id)
+    expect(response[:data][:id]).to be_a(String)
+
+    expect(response[:data]).to have_key(:type)
+    expect(response[:data][:type]).to be_a(String)
+
+    expect(response[:data]).to have_key(:attributes)
+    expect(response[:data][:attributes]).to be_a(Hash)
+
+    expect(response[:data][:attributes]).to have_key(:latitude)
+    expect(response[:data][:attributes][:latitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:longitude)
+    expect(response[:data][:attributes][:longitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:name)
+    expect(response[:data][:attributes][:name]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:description)
+    expect(response[:data][:attributes][:description]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:private)
+    expect(response[:data][:attributes][:private]).to be_in([true, false])
+
+    expect(response[:data]).to have_key(:relationships)
+    expect(response[:data][:relationships]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:user_gardens)
+    expect(response[:data][:relationships][:user_gardens]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:users)
+    expect(response[:data][:relationships][:users]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:sensors)
+    expect(response[:data][:relationships][:sensors]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:garden_plants)
+    expect(response[:data][:relationships][:garden_plants]).to be_a(Hash)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,10 +101,10 @@ def stub_omniauth
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(omniauth_google_hash)
 end
 
-VCR.configure do |config|
-  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-  config.hook_into :webmock
-  config.default_cassette_options = { re_record_interval: 7.days, record: :new_episodes }
-  config.configure_rspec_metadata!
-  config.allow_http_connections_when_no_cassette = true
-end
+# VCR.configure do |config|
+#   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+#   config.hook_into :webmock
+#   config.default_cassette_options = { re_record_interval: 7.days, record: :new_episodes }
+#   config.configure_rspec_metadata!
+#   config.allow_http_connections_when_no_cassette = true
+# end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,10 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -64,12 +67,14 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
 
     with.library :rails
   end
+end
 
 def stub_omniauth
   OmniAuth.config.test_mode = true
@@ -94,11 +99,6 @@ def stub_omniauth
       },
   }
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(omniauth_google_hash)
-end
-end
-
-RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
 end
 
 VCR.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,10 +101,10 @@ def stub_omniauth
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(omniauth_google_hash)
 end
 
-# VCR.configure do |config|
-#   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-#   config.hook_into :webmock
-#   config.default_cassette_options = { re_record_interval: 7.days, record: :new_episodes }
-#   config.configure_rspec_metadata!
-#   config.allow_http_connections_when_no_cassette = true
-# end
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.default_cassette_options = { re_record_interval: 7.days, record: :new_episodes }
+  config.configure_rspec_metadata!
+  config.allow_http_connections_when_no_cassette = true
+end

--- a/spec/services/garden_service_spec.rb
+++ b/spec/services/garden_service_spec.rb
@@ -29,8 +29,8 @@ describe GardenService do
     expect(garden_data[:data][:attributes]).to have_key(:description)
     expect(garden_data[:data][:attributes][:description]).to be_a(String)
 
-   expect(garden_data[:data][:attributes]).to have_key(:private)
-   expect(garden_data[:data][:attributes][:private]).to be_in([true, false])
+    expect(garden_data[:data][:attributes]).to have_key(:private)
+    expect(garden_data[:data][:attributes][:private]).to be_in([true, false])
 
     expect(garden_data[:data]).to have_key(:relationships)
     expect(garden_data[:data][:relationships]).to be_a(Hash)
@@ -46,5 +46,56 @@ describe GardenService do
 
     expect(garden_data[:data][:relationships]).to have_key(:garden_plants)
     expect(garden_data[:data][:relationships][:garden_plants]).to be_a(Hash)
+  end
+
+  it 'returns create new garden response' do
+    params = {"name"=>"The Grove", "latitude"=>"71.0", "longitude"=>"25.0", "private"=>"false", "description"=>"My first garden"}
+    
+    expected_output = File.read('spec/fixtures/new_garden.json')
+    stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{params[:description]}&latitude=#{params[:latitude]}&longitude=#{params[:longitude]}&name=#{params[:name]}&private=false&user_id=1").to_return(status: 200, body: expected_output, headers: {})
+
+    response = GardenService.new_garden(params.symbolize_keys, "1")
+
+    expect(response).to have_key(:data)
+    expect(response[:data]).to be_a(Hash)
+
+    expect(response[:data]).to have_key(:id)
+    expect(response[:data][:id]).to be_a(String)
+
+    expect(response[:data]).to have_key(:type)
+    expect(response[:data][:type]).to be_a(String)
+
+    expect(response[:data]).to have_key(:attributes)
+    expect(response[:data][:attributes]).to be_a(Hash)
+
+    expect(response[:data][:attributes]).to have_key(:latitude)
+    expect(response[:data][:attributes][:latitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:longitude)
+    expect(response[:data][:attributes][:longitude]).to be_a(Float)
+
+    expect(response[:data][:attributes]).to have_key(:name)
+    expect(response[:data][:attributes][:name]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:description)
+    expect(response[:data][:attributes][:description]).to be_a(String)
+
+    expect(response[:data][:attributes]).to have_key(:private)
+    expect(response[:data][:attributes][:private]).to be_in([true, false])
+
+    expect(response[:data]).to have_key(:relationships)
+    expect(response[:data][:relationships]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:user_gardens)
+    expect(response[:data][:relationships][:user_gardens]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:users)
+    expect(response[:data][:relationships][:users]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:sensors)
+    expect(response[:data][:relationships][:sensors]).to be_a(Hash)
+
+    expect(response[:data][:relationships]).to have_key(:garden_plants)
+    expect(response[:data][:relationships][:garden_plants]).to be_a(Hash)
   end
 end

--- a/spec/services/garden_service_spec.rb
+++ b/spec/services/garden_service_spec.rb
@@ -3,49 +3,8 @@ require 'rails_helper'
 describe GardenService do
   it "returns garden details data" do
     params = {id: 1}
-    garden_data = GardenService.garden_details(params)
-
-    expect(garden_data).to have_key(:data)
-    expect(garden_data[:data]).to be_a(Hash)
-
-    expect(garden_data[:data]).to have_key(:id)
-    expect(garden_data[:data][:id]).to be_a(String)
-
-    expect(garden_data[:data]).to have_key(:type)
-    expect(garden_data[:data][:type]).to be_a(String)
-
-    expect(garden_data[:data]).to have_key(:attributes)
-    expect(garden_data[:data][:attributes]).to be_a(Hash)
-
-    expect(garden_data[:data][:attributes]).to have_key(:latitude)
-    expect(garden_data[:data][:attributes][:latitude]).to be_a(Float)
-
-    expect(garden_data[:data][:attributes]).to have_key(:longitude)
-    expect(garden_data[:data][:attributes][:longitude]).to be_a(Float)
-
-    expect(garden_data[:data][:attributes]).to have_key(:name)
-    expect(garden_data[:data][:attributes][:name]).to be_a(String)
-
-    expect(garden_data[:data][:attributes]).to have_key(:description)
-    expect(garden_data[:data][:attributes][:description]).to be_a(String)
-
-    expect(garden_data[:data][:attributes]).to have_key(:private)
-    expect(garden_data[:data][:attributes][:private]).to be_in([true, false])
-
-    expect(garden_data[:data]).to have_key(:relationships)
-    expect(garden_data[:data][:relationships]).to be_a(Hash)
-
-    expect(garden_data[:data][:relationships]).to have_key(:user_gardens)
-    expect(garden_data[:data][:relationships][:user_gardens]).to be_a(Hash)
-
-    expect(garden_data[:data][:relationships]).to have_key(:users)
-    expect(garden_data[:data][:relationships][:users]).to be_a(Hash)
-
-    expect(garden_data[:data][:relationships]).to have_key(:sensors)
-    expect(garden_data[:data][:relationships][:sensors]).to be_a(Hash)
-
-    expect(garden_data[:data][:relationships]).to have_key(:garden_plants)
-    expect(garden_data[:data][:relationships][:garden_plants]).to be_a(Hash)
+    response = GardenService.garden_details(params)
+    garden_details_response_structure_check(response)
   end
 
   it 'returns create new garden response' do
@@ -53,49 +12,9 @@ describe GardenService do
     
     expected_output = File.read('spec/fixtures/new_garden.json')
     stub_request(:post, "https://solar-garden-be.herokuapp.com/api/v1/gardens?description=#{params[:description]}&latitude=#{params[:latitude]}&longitude=#{params[:longitude]}&name=#{params[:name]}&private=false&user_id=1").to_return(status: 200, body: expected_output, headers: {})
-
+    
     response = GardenService.new_garden(params.symbolize_keys, "1")
 
-    expect(response).to have_key(:data)
-    expect(response[:data]).to be_a(Hash)
-
-    expect(response[:data]).to have_key(:id)
-    expect(response[:data][:id]).to be_a(String)
-
-    expect(response[:data]).to have_key(:type)
-    expect(response[:data][:type]).to be_a(String)
-
-    expect(response[:data]).to have_key(:attributes)
-    expect(response[:data][:attributes]).to be_a(Hash)
-
-    expect(response[:data][:attributes]).to have_key(:latitude)
-    expect(response[:data][:attributes][:latitude]).to be_a(Float)
-
-    expect(response[:data][:attributes]).to have_key(:longitude)
-    expect(response[:data][:attributes][:longitude]).to be_a(Float)
-
-    expect(response[:data][:attributes]).to have_key(:name)
-    expect(response[:data][:attributes][:name]).to be_a(String)
-
-    expect(response[:data][:attributes]).to have_key(:description)
-    expect(response[:data][:attributes][:description]).to be_a(String)
-
-    expect(response[:data][:attributes]).to have_key(:private)
-    expect(response[:data][:attributes][:private]).to be_in([true, false])
-
-    expect(response[:data]).to have_key(:relationships)
-    expect(response[:data][:relationships]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:user_gardens)
-    expect(response[:data][:relationships][:user_gardens]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:users)
-    expect(response[:data][:relationships][:users]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:sensors)
-    expect(response[:data][:relationships][:sensors]).to be_a(Hash)
-
-    expect(response[:data][:relationships]).to have_key(:garden_plants)
-    expect(response[:data][:relationships][:garden_plants]).to be_a(Hash)
+    garden_details_response_structure_check(response)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'helpers'
 
 RSpec.configure do |config|
   require 'webmock/rspec'
@@ -99,5 +100,6 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.include Helpers
 end
 


### PR DESCRIPTION
closes #83, closes #87 

**What was changed**
- Added ability for user to create a new garden 
- Helper module to DRY up testing of response structures
- Created partial view to share between dashboard show (gardens section) and gardens index

**Notes**
- Used webmock to block changing of prod data in tests (vs a VCR)
- Currently to display all user's gardens, we have to make a separate call to the garden show endpoint because user's gardens doesn't display any garden attributes
  - In BE: Could potentially change user show endpoint to include details on each garden or create a new endpoint that returns a specific user's gardens + details