### PR TITLE
Convert garden name to link to garden show page

### DIFF
--- a/app/views/shared/_users_gardens_index.html.erb
+++ b/app/views/shared/_users_gardens_index.html.erb
@@ -5,8 +5,8 @@
     <% else %>
       <% @gardens.each do |garden| %>
         <section class='garden' id='garden-<%= garden.id %>'>
-          <h3><%= garden.name %></h3>
-          <div class='garden-image'>  
+          <h3><%= link_to garden.name, garden_path(garden.id) %></h3>
+          <div class='garden-image'>
             <%= image_tag 'default-garden.png' %>
           </div>
           <ul>

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'User Dashboard' do
           gardens: {
             data: [ {id: '3', type: 'garden'}, {id: '4', type: 'garden'}] }}})
 
-      garden1 = File.read('spec/fixtures/public_garden.json')
-      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/3").to_return(status: 200, body: garden1)
+      @garden1 = File.read('spec/fixtures/public_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/3").to_return(status: 200, body: @garden1)
 
-      garden2 = File.read('spec/fixtures/private_garden.json')
-      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/4").to_return(status: 200, body: garden2)
+      @garden2 = File.read('spec/fixtures/private_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/4").to_return(status: 200, body: @garden2)
     end
 
     it 'can visit their dashboard' do
@@ -47,7 +47,7 @@ RSpec.describe 'User Dashboard' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_gardens)
 
       visit dashboard_path
-      
+
       expect(page).to have_css('.garden', count: 2)
 
       within '#garden-3' do
@@ -75,6 +75,15 @@ RSpec.describe 'User Dashboard' do
         find('.delete-button').click
       end
       expect(current_path).to eq(dashboard_path)
+    end
+
+    it "can clink on the garden name to get redirected to the garden show page" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_gardens)
+
+      visit dashboard_path
+
+      click_link "The Grove"
+      expect(current_path).to eq(garden_path(3))
     end
   end
 

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe 'User Dashboard' do
           gardens: {
             data: [ {id: '3', type: 'garden'}, {id: '4', type: 'garden'}] }}})
 
-      @garden1 = File.read('spec/fixtures/public_garden.json')
-      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/3").to_return(status: 200, body: @garden1)
+      garden1 = File.read('spec/fixtures/public_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/3").to_return(status: 200, body: garden1)
 
-      @garden2 = File.read('spec/fixtures/private_garden.json')
-      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/4").to_return(status: 200, body: @garden2)
+      garden2 = File.read('spec/fixtures/private_garden.json')
+      stub_request(:get, "https://solar-garden-be.herokuapp.com/api/v1/gardens/4").to_return(status: 200, body: garden2)
     end
 
     it 'can visit their dashboard' do


### PR DESCRIPTION
**Changes Made**
- Convert garden name to link to garden show page

**Questions**
- Issue #96 also asks to add links to the show page on the Gardens Index page. 
    - Does the Gardens Index page exist? I think it's just the Dashboard page. 
    - If so, the garden-related contents of the Dashboard were put into a partial so I think this request closes that issue. 