### PR TITLE
General refactor: NavBar, Welcome Index, Garden Index

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,12 +28,6 @@
             <a class="nav-link" href="<%=dashboard_path%>">Dashboard</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="<%=dashboard_path%>">My Gardens</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/impact">My Impact</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="<%=learn_more_path%>">Learn More</a>
           </li>
         </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,19 +32,23 @@
           </li>
         </ul>
         <ul class="nav justify-content-end">
-          <li class="nav-item">
+          <li class="nav-item w3-text-gray">
             <a class="nav-link" href="<%=profile_path%>">Profile</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item w3-text-gray">
             <a class="nav-link" href="<%=logout_path%>">Logout</a>
           </li>
         </ul>
       </div>
     </nav>
   <% end %>
-  <% flash.each do |type, message| %>
-     <p><%= message %></p>
-   <% end %>
+  <center>
+    <div class="nav-item w3-light-green" style="width:500px">
+      <% flash.each do |type, message| %>
+        <p><%= message %></p>
+      <% end %>
+    </div>
+  </center>
   <%= yield %>
 </body>
 </html>

--- a/app/views/shared/_users_gardens_index.html.erb
+++ b/app/views/shared/_users_gardens_index.html.erb
@@ -7,7 +7,10 @@
         <section class='garden' id='garden-<%= garden.id %>'>
           <h3><%= link_to garden.name, garden_path(garden.id) %></h3>
           <div class='garden-image'>
-            <%= image_tag 'default-garden.png' %>
+            <a href="<%=garden_path(garden.id)%>">
+              <img alt="Image-<%= garden.id %>" src="/assets/default-garden-5bbbceb5c8def07b7a99e836154844af647a4598ec1250edaf878c68467caad9.png">
+
+            </a>
           </div>
           <ul>
             <li>Description: <%= garden.description %></li>
@@ -15,7 +18,7 @@
             <li>Longitude: <%= garden.longitude %></li>
             <li>Private? <%= garden.is_private %></li>
           </ul>
-          <%= render :partial => "shared/edit_delete_icons", locals: { 
+          <%= render :partial => "shared/edit_delete_icons", locals: {
             garden: garden } %>
         </section>
       <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -36,7 +36,9 @@
       </div>
 
 <!-- Login with Google button -->
+      <% if current_user.nil? %>
         <%= render 'shared/login_with_google_button' %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe 'User Dashboard' do
         find('.fa-edit').click
       end
 
-      # edit garden functionality not yet implemented
-      # expect(current_path).to eq("/gardens/3/edit")
       visit dashboard_path
 
       within '#garden-4' do
@@ -84,6 +82,16 @@ RSpec.describe 'User Dashboard' do
       visit dashboard_path
 
       click_link "The Grove"
+      expect(current_path).to eq(garden_path(3))
+    end
+
+    it "can clink on the garden image to get redirected to the garden show page" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_with_gardens)
+
+      visit dashboard_path
+
+      find(:xpath, "//a/img[@alt='Image-3']/..").click
+
       expect(current_path).to eq(garden_path(3))
     end
   end

--- a/spec/features/learn_more/show_spec.rb
+++ b/spec/features/learn_more/show_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Learn More page' do
 
     it "visitor does not see a navbar" do
       expect(page).to_not have_link("My Gardens")
-      expect(page).to_not have_link("My Impact")
       expect(page).to_not have_link("Learn More")
       expect(page).to_not have_link("Logout")
       expect(page).to_not have_link("Profile")
@@ -67,7 +66,6 @@ RSpec.describe 'Learn More page' do
 
     it "a logged in user can see a navbar" do
       expect(page).to have_link("Dashboard")
-      expect(page).to have_link("My Impact")
       expect(page).to have_link("Learn More")
       expect(page).to have_link("Logout")
       expect(page).to have_link("Profile")

--- a/spec/features/navbar/navbar_spec.rb
+++ b/spec/features/navbar/navbar_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -78,7 +77,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -90,7 +88,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -102,7 +99,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -114,7 +110,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -126,7 +121,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -138,7 +132,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -150,7 +143,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -162,7 +154,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -174,7 +165,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -186,7 +176,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -198,7 +187,6 @@ RSpec.describe 'Navbar' do
 
       within "#navbar-#{@user.id}" do
         expect(page).to have_link('Dashboard')
-        expect(page).to have_link('My Impact')
         expect(page).to have_link('Learn More')
         expect(page).to have_link('Profile')
         expect(page).to have_link('Logout')
@@ -215,7 +203,6 @@ RSpec.describe 'Navbar' do
         click_link 'Logout'
 
         expect(page).to_not have_link('My Gardens')
-        expect(page).to_not have_link('My Impact')
         expect(page).to_not have_link('Profile')
         expect(page).to_not have_link('Logout')
       end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -85,5 +85,18 @@ RSpec.describe 'Welcome' do
       click_link "Login with Google"
       expect(current_path).to eq(dashboard_path)
     end
+
+    it "expects to not see Login With Google if logged in" do
+      @user = User.new({id: 2,
+                        attributes: {
+                          email: 'planter@gmail.com' },
+                          relationships: {
+                            gardens: {
+                              data: [ {id: '3', type: 'garden'}, {id: '4', type: 'garden'}] }}})
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit root_path
+
+      expect(page).to_not have_content("Login with Google")
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/On_the_garden_show_page/as_a_logged_in_user/I_can_delete_a_sensor.yml
+++ b/spec/fixtures/vcr_cassettes/On_the_garden_show_page/as_a_logged_in_user/I_can_delete_a_sensor.yml
@@ -1,0 +1,221 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://solar-garden-be.herokuapp.com/api/v1/gardens/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 04 Nov 2020 23:54:18 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"87cf4c170b0401e70b3256ac8cb6b3e5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 890e6f67-6dd9-4f76-abe8-66738f982bda
+      X-Runtime:
+      - '0.172007'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1","type":"garden","attributes":{"latitude":41.0,"longitude":41.0,"name":"A
+        garden","description":"a garden","private":false},"relationships":{"user_gardens":{"data":[{"id":"291","type":"user_garden"}]},"users":{"data":[{"id":"2","type":"user"}]},"sensors":{"data":[{"id":"33","type":"sensor"},{"id":"34","type":"sensor"},{"id":"35","type":"sensor"},{"id":"36","type":"sensor"},{"id":"37","type":"sensor"},{"id":"38","type":"sensor"},{"id":"39","type":"sensor"},{"id":"40","type":"sensor"},{"id":"41","type":"sensor"},{"id":"42","type":"sensor"},{"id":"43","type":"sensor"},{"id":"44","type":"sensor"},{"id":"45","type":"sensor"},{"id":"46","type":"sensor"},{"id":"47","type":"sensor"},{"id":"48","type":"sensor"},{"id":"49","type":"sensor"},{"id":"50","type":"sensor"},{"id":"51","type":"sensor"},{"id":"52","type":"sensor"},{"id":"53","type":"sensor"},{"id":"54","type":"sensor"},{"id":"55","type":"sensor"},{"id":"56","type":"sensor"},{"id":"57","type":"sensor"},{"id":"58","type":"sensor"},{"id":"59","type":"sensor"},{"id":"60","type":"sensor"},{"id":"61","type":"sensor"},{"id":"62","type":"sensor"},{"id":"63","type":"sensor"},{"id":"80","type":"sensor"},{"id":"81","type":"sensor"},{"id":"82","type":"sensor"},{"id":"86","type":"sensor"},{"id":"87","type":"sensor"},{"id":"88","type":"sensor"},{"id":"13","type":"sensor"}]},"garden_plants":{"data":[]},"plants":{"data":[]}}}}'
+  recorded_at: Wed, 04 Nov 2020 23:54:19 GMT
+- request:
+    method: get
+    uri: https://solar-garden-be.herokuapp.com/api/v1/gardens/1/sensors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 04 Nov 2020 23:54:19 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"485bb4233cf7ccf0ad5461db23e92997"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b2f20e56-829c-4e88-81da-8cb162516745
+      X-Runtime:
+      - '0.454647'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"33","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"34","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"35","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"36","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"37","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"38","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"39","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"40","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"41","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"42","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"43","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"44","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"45","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"46","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"47","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"48","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"49","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"50","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"51","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"52","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"53","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"54","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"55","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"56","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"57","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"58","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"59","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"60","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"61","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"62","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"63","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"80","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"81","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"82","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"86","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"87","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"88","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"13","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"light"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[{"id":"40","type":"garden_health"},{"id":"42","type":"garden_health"},{"id":"44","type":"garden_health"},{"id":"46","type":"garden_health"},{"id":"48","type":"garden_health"},{"id":"50","type":"garden_health"},{"id":"52","type":"garden_health"},{"id":"54","type":"garden_health"}]}}}]}'
+  recorded_at: Wed, 04 Nov 2020 23:54:20 GMT
+- request:
+    method: delete
+    uri: https://solar-garden-be.herokuapp.com/api/v1/sensors/33
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 04 Nov 2020 23:54:19 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 6c32fc13-baaa-478e-85de-f5a50efe1e40
+      X-Runtime:
+      - '0.054904'
+      Vary:
+      - Origin
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 04 Nov 2020 23:54:20 GMT
+- request:
+    method: get
+    uri: https://solar-garden-be.herokuapp.com/api/v1/gardens/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 04 Nov 2020 23:54:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"aaf37c339e1ef135a7f2eeacb6a628de"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cecfad2f-25d9-4c57-8520-678f1872af0d
+      X-Runtime:
+      - '0.045403'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1","type":"garden","attributes":{"latitude":41.0,"longitude":41.0,"name":"A
+        garden","description":"a garden","private":false},"relationships":{"user_gardens":{"data":[{"id":"291","type":"user_garden"}]},"users":{"data":[{"id":"2","type":"user"}]},"sensors":{"data":[{"id":"34","type":"sensor"},{"id":"35","type":"sensor"},{"id":"36","type":"sensor"},{"id":"37","type":"sensor"},{"id":"38","type":"sensor"},{"id":"39","type":"sensor"},{"id":"40","type":"sensor"},{"id":"41","type":"sensor"},{"id":"42","type":"sensor"},{"id":"43","type":"sensor"},{"id":"44","type":"sensor"},{"id":"45","type":"sensor"},{"id":"46","type":"sensor"},{"id":"47","type":"sensor"},{"id":"48","type":"sensor"},{"id":"49","type":"sensor"},{"id":"50","type":"sensor"},{"id":"51","type":"sensor"},{"id":"52","type":"sensor"},{"id":"53","type":"sensor"},{"id":"54","type":"sensor"},{"id":"55","type":"sensor"},{"id":"56","type":"sensor"},{"id":"57","type":"sensor"},{"id":"58","type":"sensor"},{"id":"59","type":"sensor"},{"id":"60","type":"sensor"},{"id":"61","type":"sensor"},{"id":"62","type":"sensor"},{"id":"63","type":"sensor"},{"id":"80","type":"sensor"},{"id":"81","type":"sensor"},{"id":"82","type":"sensor"},{"id":"86","type":"sensor"},{"id":"87","type":"sensor"},{"id":"88","type":"sensor"},{"id":"13","type":"sensor"}]},"garden_plants":{"data":[]},"plants":{"data":[]}}}}'
+  recorded_at: Wed, 04 Nov 2020 23:54:21 GMT
+- request:
+    method: get
+    uri: https://solar-garden-be.herokuapp.com/api/v1/gardens/1/sensors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 04 Nov 2020 23:54:21 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"22df3164e892f52b0ae87c09d0eda310"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b95207e-202e-445b-88b0-2b889a04e284
+      X-Runtime:
+      - '0.304771'
+      Vary:
+      - Origin
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"34","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"35","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"36","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"37","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"38","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"39","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"40","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"41","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"42","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"43","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"44","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"45","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"46","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"47","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"48","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"49","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"50","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"51","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"52","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"53","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"54","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"55","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"56","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"57","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"58","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"59","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"60","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"61","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"62","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"63","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"80","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"81","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"82","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"86","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"87","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"88","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"moisture"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[]}}},{"id":"13","type":"sensor","attributes":{"min_threshold":5,"max_threshold":10,"sensor_type":"light"},"relationships":{"garden":{"data":{"id":"1","type":"garden"}},"garden_healths":{"data":[{"id":"40","type":"garden_health"},{"id":"42","type":"garden_health"},{"id":"44","type":"garden_health"},{"id":"46","type":"garden_health"},{"id":"48","type":"garden_health"},{"id":"50","type":"garden_health"},{"id":"52","type":"garden_health"},{"id":"54","type":"garden_health"}]}}}]}'
+  recorded_at: Wed, 04 Nov 2020 23:54:21 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
# General Refactor

This PR:

- Cleans up the Nav Bar, taking out `My Gardens` and `My Impact`.
- Changes `Profile` and `Logout` so they're gray now (still not sure what's going on with why they weren't gray already)
- Updates Welcome Index so you can't see "Login With Google" when you're logged in.
- Updates the styling of the flash messages.
- Updates Garden Index so you can click on the image and be sent to the Garden Show (took 30 seconds to implement and test, so I did it because it felt weird to not be able to do that).

Closes #117 
Closes #118 
Closes #115 

Side note: this will have all that Drew and Leah have done that hasn't been merged in yet.

Coverage is at 97.1%, because of the four skipped tests.